### PR TITLE
feat: add quota report command and brief panel in dashboard

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -521,6 +521,72 @@ program
     console.log('')
   })
 
+// ─── clauditor report ────────────────────────────────────────────
+
+program
+  .command('report')
+  .description('Show quota usage report — see where your tokens went')
+  .option('-d, --days <n>', 'Number of days to look back', '7')
+  .option('--json', 'Output as JSON')
+  .action(async (options) => {
+    const { computeQuotaBrief } = await import('./features/quota-report.js')
+    const days = parseInt(options.days, 10) || 7
+    const brief = computeQuotaBrief(days)
+
+    if (options.json) {
+      console.log(JSON.stringify(brief, null, 2))
+      return
+    }
+
+    if (brief.totalSessions === 0) {
+      console.log('No sessions found in the last ' + days + ' days.')
+      return
+    }
+
+    console.log('')
+    console.log(`  Quota Report — last ${days} days`)
+    console.log('  ' + '─'.repeat(58))
+    console.log('')
+    console.log('  TURNS  BASE   NOW   WASTE  TOKENS')
+    console.log('  ' + '─'.repeat(58))
+
+    for (const s of brief.sessions) {
+      const barLen = Math.min(25, Math.round(s.wasteFactor))
+      const bar = '█'.repeat(barLen)
+      const color = s.wasteFactor >= 5 ? '\x1b[31m' : s.wasteFactor >= 3 ? '\x1b[33m' : '\x1b[32m'
+      const reset = '\x1b[0m'
+
+      console.log(
+        `  ${String(s.turns).padStart(5)}  ` +
+        `${(s.baselineK + 'k').padStart(4)}  ` +
+        `${(s.currentK + 'k').padStart(4)}  ` +
+        `${color}${(s.wasteFactor + 'x').padStart(5)}${reset}  ` +
+        `${(Math.round(s.totalTokens / 1e6) + 'M').padStart(5)}  ` +
+        `${color}${bar}${reset}`
+      )
+    }
+
+    console.log('  ' + '─'.repeat(58))
+    console.log('')
+    console.log(`  ${brief.totalSessions} sessions · ${(brief.totalTokens / 1e6).toFixed(0)}M tokens total`)
+    if (brief.sessionsOver5x > 0) {
+      console.log(`  \x1b[31m${brief.sessionsOver5x} sessions burned 5x+ more quota than necessary\x1b[0m`)
+    }
+    if (brief.sessionsOver3x > 0 && brief.sessionsOver3x > brief.sessionsOver5x) {
+      console.log(`  \x1b[33m${brief.sessionsOver3x - brief.sessionsOver5x} more sessions used 3-5x quota\x1b[0m`)
+    }
+
+    if (brief.worstSession && brief.worstSession.wasteFactor >= 3) {
+      const w = brief.worstSession
+      console.log('')
+      console.log(`  Worst: ${w.label} (${w.turns} turns)`)
+      console.log(`  Started at ${w.baselineK}k/turn, ended at ${w.currentK}k/turn (${w.wasteFactor}x waste)`)
+      console.log(`  With rotation, this session would have used ~${Math.round(w.turns * w.baselineK * 2 / 1000)}M tokens instead of ${Math.round(w.totalTokens / 1e6)}M`)
+    }
+
+    console.log('')
+  })
+
 // ─── clauditor sessions ──────────────────────────────────────────
 
 program

--- a/src/features/quota-report.ts
+++ b/src/features/quota-report.ts
@@ -1,0 +1,144 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { resolve, sep, basename } from 'node:path'
+
+export interface SessionReport {
+  file: string
+  label: string
+  turns: number
+  baselineK: number
+  currentK: number
+  wasteFactor: number
+  totalTokens: number
+  date: Date
+}
+
+export interface QuotaBrief {
+  totalSessions: number
+  totalTokens: number
+  sessionsOver3x: number
+  sessionsOver5x: number
+  worstSession: SessionReport | null
+  sessions: SessionReport[]
+}
+
+/**
+ * Analyze all sessions across all projects for the last N days.
+ * Deduplicates continued sessions by message ID.
+ */
+export function computeQuotaBrief(days: number = 7): QuotaBrief {
+  const projectsDir = resolve(homedir(), '.claude/projects')
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+  const sessions: SessionReport[] = []
+  const seenMessageIds = new Set<string>()
+
+  let projectDirs: string[]
+  try {
+    projectDirs = readdirSync(projectsDir, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => d.name)
+  } catch {
+    return { totalSessions: 0, totalTokens: 0, sessionsOver3x: 0, sessionsOver5x: 0, worstSession: null, sessions: [] }
+  }
+
+  for (const projDir of projectDirs) {
+    const projPath = resolve(projectsDir, projDir)
+    let files: string[]
+    try {
+      files = readdirSync(projPath).filter(f => f.endsWith('.jsonl'))
+    } catch {
+      continue
+    }
+
+    // Derive a human label from the encoded project path
+    const label = projDir
+      .replace(/^-/, '')
+      .split('-')
+      .slice(-2)
+      .join('/')
+
+    for (const file of files) {
+      const filePath = resolve(projPath, file)
+      try {
+        const stat = statSync(filePath)
+        if (stat.mtime < cutoff) continue
+
+        const report = analyzeSessionFile(filePath, label, seenMessageIds)
+        if (report) sessions.push(report)
+      } catch {
+        continue
+      }
+    }
+  }
+
+  sessions.sort((a, b) => b.wasteFactor - a.wasteFactor)
+
+  const totalTokens = sessions.reduce((s, r) => s + r.totalTokens, 0)
+
+  return {
+    totalSessions: sessions.length,
+    totalTokens,
+    sessionsOver3x: sessions.filter(s => s.wasteFactor >= 3).length,
+    sessionsOver5x: sessions.filter(s => s.wasteFactor >= 5).length,
+    worstSession: sessions[0] || null,
+    sessions,
+  }
+}
+
+function analyzeSessionFile(
+  filePath: string,
+  label: string,
+  seenMessageIds: Set<string>
+): SessionReport | null {
+  const content = readFileSync(filePath, 'utf-8')
+  const lines = content.split('\n').filter(Boolean)
+
+  const turnTotals: number[] = []
+  let totalTokens = 0
+  let isAllDuplicate = true
+  let lastTimestamp: string | null = null
+
+  for (const line of lines) {
+    try {
+      const r = JSON.parse(line)
+      if (r.type === 'assistant' && r.message?.usage) {
+        const msgId = r.message?.id
+        if (msgId && seenMessageIds.has(msgId)) {
+          continue // skip duplicate turns from continued sessions
+        }
+        if (msgId) {
+          seenMessageIds.add(msgId)
+          isAllDuplicate = false
+        }
+
+        const u = r.message.usage
+        const total = (u.input_tokens || 0) + (u.output_tokens || 0) +
+          (u.cache_read_input_tokens || 0) + (u.cache_creation_input_tokens || 0)
+        turnTotals.push(total)
+        totalTokens += total
+        if (r.timestamp) lastTimestamp = r.timestamp
+      }
+    } catch {
+      // skip malformed lines
+    }
+  }
+
+  // Skip files that are entirely duplicate (continuation with no new turns)
+  if (isAllDuplicate && turnTotals.length === 0) return null
+  if (turnTotals.length < 3) return null
+
+  const baseline = turnTotals.slice(0, 5).reduce((a, b) => a + b, 0) / Math.min(5, turnTotals.length)
+  const current = turnTotals.slice(-5).reduce((a, b) => a + b, 0) / Math.min(5, turnTotals.length)
+  const wasteFactor = baseline > 0 ? Math.round((current / baseline) * 10) / 10 : 1
+
+  return {
+    file: basename(filePath).replace('.jsonl', '').slice(0, 8),
+    label,
+    turns: turnTotals.length,
+    baselineK: Math.round(baseline / 1000),
+    currentK: Math.round(current / 1000),
+    wasteFactor,
+    totalTokens,
+    date: lastTimestamp ? new Date(lastTimestamp) : new Date(),
+  }
+}

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -4,6 +4,7 @@ import type { SessionState } from '../types.js'
 import { SessionStore } from '../daemon/store.js'
 import { Dashboard } from './dashboard.js'
 import { readActivity, type ActivityEvent } from '../features/activity-log.js'
+import { computeQuotaBrief, type QuotaBrief } from '../features/quota-report.js'
 
 interface AppProps {
   store: SessionStore
@@ -43,6 +44,7 @@ export function App({ store, projectPath }: AppProps) {
   const { exit } = useApp()
   const [sessions, setSessions] = useState<SessionState[]>([])
   const [activity, setActivity] = useState<ActivityEvent[]>([])
+  const [brief, setBrief] = useState<QuotaBrief | null>(null)
 
   useInput((input, key) => {
     if (input === 'q' || (key.ctrl && input === 'c')) {
@@ -72,6 +74,16 @@ export function App({ store, projectPath }: AppProps) {
     return () => clearInterval(interval)
   }, [])
 
+  // Compute quota brief on mount and every 60s
+  useEffect(() => {
+    const load = () => {
+      try { setBrief(computeQuotaBrief(7)) } catch {}
+    }
+    load()
+    const interval = setInterval(load, 60_000)
+    return () => clearInterval(interval)
+  }, [])
+
   // Show the most recent main session (not subagent)
   const mainSessions = sessions.filter((s) => !s.sessionId.startsWith('agent-'))
   const activeSession = mainSessions[0] || sessions[0]
@@ -90,6 +102,27 @@ export function App({ store, projectPath }: AppProps) {
         </Text>
         <Text dimColor>  {recentMainCount} sessions + {recentSubCount} subagents (last 12h)</Text>
       </Box>
+
+      {/* Quota brief — the "wow" panel */}
+      {brief && brief.totalSessions >= 3 && (
+        <Box flexDirection="column" marginBottom={1}>
+          <Text bold dimColor>LAST 7 DAYS</Text>
+          <Text>
+            {brief.totalSessions} sessions · {brief.sessionsOver5x > 0 ? (
+              <Text color="red" bold>{brief.sessionsOver5x} burned 5x+ quota</Text>
+            ) : brief.sessionsOver3x > 0 ? (
+              <Text color="yellow">{brief.sessionsOver3x} used 3x+ quota</Text>
+            ) : (
+              <Text color="green">all sessions efficient</Text>
+            )}
+          </Text>
+          {brief.worstSession && brief.worstSession.wasteFactor >= 3 && (
+            <Text dimColor>
+              Worst: {brief.worstSession.label} ({brief.worstSession.turns} turns, {brief.worstSession.wasteFactor}x waste — {brief.worstSession.baselineK}k→{brief.worstSession.currentK}k/turn)
+            </Text>
+          )}
+        </Box>
+      )}
 
       {sessions.length === 0 ? (
         <Box>


### PR DESCRIPTION
- `clauditor report` shows per-session waste analysis sorted by waste factor, with color-coded bars, counterfactual estimates, and totals
- Dashboard (clauditor watch) now shows a "LAST 7 DAYS" brief panel with session count, how many burned 5x+ quota, and worst session details
- Deduplicates continued sessions by message ID to avoid overcounting tokens when Claude Code copies history into new JSONL files on --continue
