### PR TITLE
fix: skip meta messages in handoff, fix HEREDOC commit parsing

### DIFF
--- a/src/features/session-state.test.ts
+++ b/src/features/session-state.test.ts
@@ -190,6 +190,46 @@ describe('extractSessionStateFromTranscript', () => {
     expect(result!.originalTask!.length).toBeLessThanOrEqual(303) // 300 + '...'
   })
 
+  it('skips meta messages for original task', () => {
+    const lines = [
+      // Meta message (isMeta: true) — should be skipped
+      makeUserRecord('meta', '<local-command-caveat>Do not respond</local-command-caveat>', { isMeta: true }),
+      // Real user message
+      makeUserRecord('1', 'Build a REST API'),
+      ...Array.from({ length: 6 }, (_, i) => makeAssistantRecord(`a${i}`, { text: `response ${i}` })),
+    ]
+    const result = extractSessionStateFromTranscript('s1', writeSession(lines))
+    expect(result).not.toBeNull()
+    expect(result!.originalTask).toBe('Build a REST API')
+    expect(result!.originalTask).not.toContain('local-command-caveat')
+  })
+
+  it('skips messages starting with XML tags', () => {
+    const lines = [
+      makeUserRecord('1', '<command-name>/clear</command-name>'),
+      makeUserRecord('2', 'The real task starts here'),
+      ...Array.from({ length: 6 }, (_, i) => makeAssistantRecord(`a${i}`, { text: `response ${i}` })),
+    ]
+    const result = extractSessionStateFromTranscript('s1', writeSession(lines))
+    expect(result).not.toBeNull()
+    expect(result!.originalTask).toBe('The real task starts here')
+  })
+
+  it('extracts git commits from HEREDOC format', () => {
+    const heredocCmd = "git commit -m \"$(cat <<'EOF'\nfeat: add new feature\n\nhttps://claude.ai/code/session_123\nEOF\n)\""
+    const lines = [
+      makeUserRecord('1', 'Do work'),
+      ...Array.from({ length: 5 }, (_, i) =>
+        makeAssistantRecord(`a${i}`, {
+          toolCalls: [{ name: 'Bash', input: { command: heredocCmd } }],
+        })
+      ),
+    ]
+    const result = extractSessionStateFromTranscript('s1', writeSession(lines))
+    expect(result).not.toBeNull()
+    expect(result!.gitCommits).toContain('feat: add new feature')
+  })
+
   it('truncates last assistant message to 500 chars', () => {
     const longMsg = 'y'.repeat(1000)
     const lines = [

--- a/src/features/session-state.ts
+++ b/src/features/session-state.ts
@@ -141,10 +141,10 @@ export function extractSessionStateFromTranscript(
       try {
         const r = JSON.parse(line)
 
-        // Extract user messages
-        if (r.type === 'user') {
+        // Extract user messages (skip meta/system messages)
+        if (r.type === 'user' && !r.isMeta) {
           const msg = extractUserMessage(r)
-          if (msg) {
+          if (msg && !msg.startsWith('<')) {
             userMessages.push(msg)
             if (!originalTask) originalTask = msg
           }
@@ -191,12 +191,24 @@ export function extractSessionStateFromTranscript(
 
               // Git commits — various formats
               if (cmd.includes('git') && cmd.includes('commit')) {
-                const match = cmd.match(/-m\s+["']([^"']+)["']/) ||
-                  cmd.match(/-m\s+"?\$\(cat <<[^)]+\n\s*([^\n]+)/) ||
-                  cmd.match(/commit\s+-m\s+"([^"]+)"/) ||
-                  cmd.match(/commit\s+-m\s+'([^']+)'/)
-                if (match) {
-                  gitCommits.push(match[1].trim().slice(0, 120))
+                let commitMsg: string | null = null
+
+                // HEREDOC format first (most common in Claude Code): -m "$(cat <<'EOF'\nmessage\nEOF\n)"
+                if (cmd.includes('<<')) {
+                  const heredocMatch = cmd.match(/<<['"]?EOF['"]?\)?\s*\n\s*(.+)/)
+                  if (heredocMatch) commitMsg = heredocMatch[1].trim()
+                }
+
+                // Standard formats: -m "message" or -m 'message'
+                if (!commitMsg) {
+                  const match = cmd.match(/-m\s+["']([^"'\n]+)["']/) ||
+                    cmd.match(/commit\s+-m\s+"([^"\n]+)"/) ||
+                    cmd.match(/commit\s+-m\s+'([^'\n]+)'/)
+                  if (match) commitMsg = match[1].trim()
+                }
+
+                if (commitMsg) {
+                  gitCommits.push(commitMsg.slice(0, 120))
                 }
               }
 


### PR DESCRIPTION
## Summary
- Original task no longer captures meta messages (isMeta: true) or XML-tagged system messages
- Git commit extraction now handles HEREDOC format (most common in Claude Code) before standard formats
- Both bugs were found from real user session data

## Test plan
- [x] 3 new tests: meta skip, XML skip, HEREDOC parsing
- [x] Full suite passes (73 tests)
