### PR TITLE
fix: make Claude explicitly acknowledge session handoff on start

### DIFF
--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -57,9 +57,11 @@ async function buildSessionStartContext(
     if (lastState) {
       parts.push(
         `[clauditor — previous session context]:\n` +
-        `The previous session was rotated because it was too large. Here's what was saved:\n\n` +
+        `The previous session was rotated by clauditor because it was too large. Here's what was saved:\n\n` +
         lastState + `\n` +
-        `Use this context to pick up where the user left off.`
+        `IMPORTANT: Tell the user "I have context from your previous session" and briefly summarize what you see ` +
+        `(branch, what was being worked on, where it left off). Then ask if they want to continue from there. ` +
+        `Do NOT start working silently — acknowledge the handoff first.`
       )
     }
 


### PR DESCRIPTION
Users reported that after rotation, the new session appeared empty because Claude received the context silently via additionalContext but didn't announce it. Now the injection tells Claude to:
1. Tell the user "I have context from your previous session"
2. Summarize what it sees (branch, task, where it left off)
3. Ask if they want to continue