### PR TITLE
fix/continue-block-exit-code-2

### DIFF
--- a/src/hooks/user-prompt-submit.ts
+++ b/src/hooks/user-prompt-submit.ts
@@ -41,9 +41,12 @@ export async function handleUserPromptSubmitHook(): Promise<void> {
   }
 
   // Check if this is a "continue" prompt — if so, block with handoff context
+  // Uses exit code 2 + stderr (same as PostToolUse rotation) which works in both CLI and VS Code
   const continueBlock = checkContinuePrompt(hookInput)
   if (continueBlock) {
-    process.stdout.write(JSON.stringify(continueBlock))
+    process.stderr.write(continueBlock.reason)
+    process.stdout.write('{}')
+    process.exit(2)
     return
   }
 


### PR DESCRIPTION
## Summary
- JSON `decision:"block"` only works in CLI, not VS Code extension
- Switched to exit code 2 + stderr (same as PostToolUse rotation blocks)
- This is the universal blocking mechanism across CLI and VS Code

## Test plan
- [x] 131 tests pass
- [ ] Test in CLI: type "continue" → should block with session choices
- [ ] Test in VS Code: type "continue" → should now block (previously didn't)
