### PR TITLE
fix: extract meaningful descriptions from handoff files

### DIFF
--- a/src/features/session-state.ts
+++ b/src/features/session-state.ts
@@ -145,6 +145,68 @@ export interface HandoffFile {
 }
 
 /**
+ * Extract a human-readable one-line description from a handoff file.
+ * Tries multiple strategies depending on the content format.
+ */
+export function extractHandoffDescription(handoff: HandoffFile): string {
+  const lines = handoff.content.split('\n')
+
+  // PostCompact: look for first meaningful line after <analysis> or after the header
+  if (handoff.isPostCompact) {
+    for (const line of lines) {
+      const trimmed = line.trim()
+      // Skip headers, empty lines, blockquotes, and tags
+      if (!trimmed) continue
+      if (trimmed.startsWith('#')) continue
+      if (trimmed.startsWith('>')) continue
+      if (trimmed.startsWith('<')) continue
+      // Found a meaningful line — extract key info
+      // Often starts with "1." or "- " or "Let me" or "User asked"
+      const clean = trimmed.replace(/^\d+\.\s*\*\*[^*]+\*\*:?\s*/, '').replace(/^\*\*[^*]+\*\*:?\s*/, '')
+      if (clean.length > 10) return clean.slice(0, 100)
+    }
+  }
+
+  // Mechanical: build from branch + original task or where we left off
+  const branch = lines.find(l => l.startsWith('- **Branch:**'))?.replace('- **Branch:** ', '') || null
+
+  // Look for "## Where We Left Off" content
+  const woIdx = lines.findIndex(l => l.startsWith('## Where We Left Off'))
+  if (woIdx >= 0 && lines[woIdx + 1]?.trim()) {
+    const leftOff = lines[woIdx + 1].trim().slice(0, 80)
+    if (leftOff.length > 10 && !leftOff.startsWith('<') && !leftOff.startsWith('[Request')) {
+      return branch ? `${branch} — ${leftOff}` : leftOff
+    }
+  }
+
+  // Look for "## Original Task" content
+  const taskIdx = lines.findIndex(l => l.startsWith('## Original Task'))
+  if (taskIdx >= 0 && lines[taskIdx + 1]?.trim()) {
+    const task = lines[taskIdx + 1].trim().slice(0, 80)
+    if (task.length > 10 && !task.startsWith('<') && !task.startsWith('[Request')) {
+      return branch ? `${branch} — ${task}` : task
+    }
+  }
+
+  // Look for recent user messages
+  const msgIdx = lines.findIndex(l => l.startsWith('## Recent User Messages'))
+  if (msgIdx >= 0) {
+    for (let i = msgIdx + 1; i < lines.length && i < msgIdx + 4; i++) {
+      const msg = lines[i]?.replace(/^>\s*/, '').trim()
+      if (msg && msg.length > 10 && !msg.startsWith('<') && !msg.startsWith('[Request')) {
+        return branch ? `${branch} — ${msg.slice(0, 80)}` : msg.slice(0, 80)
+      }
+    }
+  }
+
+  // Fallback: branch + session size
+  const sizeLine = lines.find(l => l.startsWith('- **Session size:**'))?.replace('- **Session size:** ', '')
+  if (branch) return sizeLine ? `${branch} (${sizeLine})` : branch
+
+  return handoff.isPostCompact ? 'Claude-generated summary' : 'Session snapshot'
+}
+
+/**
  * Read recent handoff files for a given cwd (last 24 hours).
  * Returns them sorted by timestamp, most recent first.
  */

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -56,7 +56,7 @@ async function buildSessionStartContext(
     }
 
     // Inject session handoff(s) if available
-    const { readRecentHandoffs } = await import('../features/session-state.js')
+    const { readRecentHandoffs, extractHandoffDescription } = await import('../features/session-state.js')
     const handoffs = readRecentHandoffs(cwd || null)
 
     if (handoffs.length === 1) {
@@ -79,22 +79,7 @@ async function buildSessionStartContext(
       const options = handoffs.slice(0, 5).map((h, i) => {
         const timeAgo = Math.round((Date.now() - h.timestamp) / 60000)
         const timeStr = timeAgo < 60 ? `${timeAgo}m ago` : `${Math.round(timeAgo / 60)}h ago`
-        // Extract a meaningful one-line description
-        const lines = h.content.split('\n')
-        const branchLine = lines.find(l => l.startsWith('- **Branch:**'))
-        const taskLine = lines.find(l => l.startsWith('## Original Task'))
-        const whereLeftOff = lines.find(l => l.startsWith('## Where We Left Off'))
-
-        let description = ''
-        if (branchLine) description += branchLine.replace('- **Branch:** ', '') + ' — '
-        if (taskLine) {
-          const taskIdx = lines.indexOf(taskLine)
-          if (taskIdx >= 0 && lines[taskIdx + 1]) description += lines[taskIdx + 1].slice(0, 80)
-        } else if (whereLeftOff) {
-          const woIdx = lines.indexOf(whereLeftOff)
-          if (woIdx >= 0 && lines[woIdx + 1]) description += lines[woIdx + 1].slice(0, 80)
-        }
-        if (!description) description = h.isPostCompact ? 'Rich session summary' : 'Session snapshot'
+        const description = extractHandoffDescription(h)
 
         return `${i + 1}. (${timeStr}) ${description}`
       }).join('\n')

--- a/src/hooks/user-prompt-submit.ts
+++ b/src/hooks/user-prompt-submit.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { saveSessionState as saveSState, extractSessionStateFromTranscript, readRecentHandoffs } from '../features/session-state.js'
+import { saveSessionState as saveSState, extractSessionStateFromTranscript, readRecentHandoffs, extractHandoffDescription } from '../features/session-state.js'
 import { readConfig } from '../config.js'
 import { loadCalibration } from '../features/calibration.js'
 import { homedir } from 'node:os'
@@ -280,21 +280,7 @@ function checkContinuePrompt(hookInput: UserPromptSubmitInput): { decision: stri
   const options = handoffs.slice(0, 5).map((h, i) => {
     const timeAgo = Math.round((Date.now() - h.timestamp) / 60000)
     const timeStr = timeAgo < 60 ? `${timeAgo}m ago` : `${Math.round(timeAgo / 60)}h ago`
-    const lines = h.content.split('\n')
-    const branchLine = lines.find(l => l.startsWith('- **Branch:**'))
-    const taskLine = lines.find(l => l.startsWith('## Original Task'))
-    const whereLeftOff = lines.find(l => l.startsWith('## Where We Left Off'))
-
-    let description = ''
-    if (branchLine) description += branchLine.replace('- **Branch:** ', '') + ' — '
-    if (taskLine) {
-      const taskIdx = lines.indexOf(taskLine)
-      if (taskIdx >= 0 && lines[taskIdx + 1]) description += lines[taskIdx + 1].slice(0, 80)
-    } else if (whereLeftOff) {
-      const woIdx = lines.indexOf(whereLeftOff)
-      if (woIdx >= 0 && lines[woIdx + 1]) description += lines[woIdx + 1].slice(0, 80)
-    }
-    if (!description) description = h.isPostCompact ? 'Rich session summary' : 'Session snapshot'
+    const description = extractHandoffDescription(h)
 
     return `  ${i + 1}. (${timeStr}) ${description}`
   }).join('\n')


### PR DESCRIPTION
## Summary
- "Rich session summary" and "[Request interrupted by user]" replaced with actual content
- PostCompact files: extracts first meaningful line from Claude's summary
- Mechanical files: uses branch + Where We Left Off / Original Task / Recent Messages
- Shared extractHandoffDescription() used by both UserPromptSubmit and SessionStart

## Test plan
- [x] 131 tests pass
- [ ] Test locally: type "continue" → descriptions should show actual session content
