### PR TITLE
docs: comprehensive README update reflecting current features

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,31 @@ clauditor monitors your session size and **blocks Claude when you're wasting quo
 
 ```
 ╔══════════════════════════════════════════════════════════════╗
-║  clauditor: Session using 16x more quota than necessary     ║
+║  clauditor: Session using 9x more quota than necessary      ║
 ╚══════════════════════════════════════════════════════════════╝
 
-Your turns started at 25k tokens.
-They're now at 398k tokens.
-Each turn uses 16x more quota than when this session started.
+This session is burning 9x more quota per turn (170k vs ~20k tokens/turn).
+Your progress has been saved and won't be lost.
 
-Session state saved.
-  Branch: feat/variable-agent
-  Files: FileAgent.cs, ServiceCollectionExtensions.cs, +13 more
-  Turns: 889
-
-Start fresh: run `claude` — clauditor will inject your previous session context.
+Run `claude` to start a fresh session at ~20k tokens/turn instead of 170k.
+In the new session, just say "continue where I left off".
 ```
 
-Claude sees this, stops, and tells you to start a fresh session. Your context is preserved. Zero tokens wasted.
+When you type "continue" in the new session, clauditor shows your saved sessions and tells you exactly what to type:
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║  clauditor: 2 recent sessions found                        ║
+╚══════════════════════════════════════════════════════════════╝
+
+  1. (5m ago) Notion backfill — populating database with User Email
+     → read ~/.clauditor/sessions/.../1234.md and continue where I left off
+
+  2. (30m ago) feat/variable-agent — migrating from ResponsesApi
+     → read ~/.clauditor/sessions/.../5678.md and continue where I left off
+
+Copy one of the → lines above, or type something else to start fresh.
+```
 
 ## Install
 
@@ -57,17 +66,30 @@ clauditor install
 
 That's it. Two commands. clauditor registers hooks into Claude Code and runs in the background. No dashboard needed. No config needed.
 
+**Also works with npx** (no global install):
+
+```bash
+npx @iyadhk/clauditor install
+```
+
+Hooks are registered to run via npx automatically.
+
 Requires Node.js 20+.
 
 **Supported platforms:** Claude Code CLI, VS Code extension, JetBrains extension. Does **not** work with Claude Code on the web (claude.ai/code).
 
+**Known limitation:** The "continue" prompt block works reliably in the CLI. In the VS Code extension, the `UserPromptSubmit` hook [may not fire consistently](https://github.com/anthropics/claude-code/issues/17277) — context is still injected via `SessionStart` but Claude may not always announce it. This is a Claude Code bug, not a clauditor issue.
+
 ## How it works
 
-clauditor registers 5 hooks into Claude Code:
+clauditor registers 6 hooks into Claude Code:
 
 ### `UserPromptSubmit` — blocks before tokens are wasted
 
-Before Claude processes your prompt, clauditor checks the **waste factor**: how many more tokens per turn you're using compared to the start of your session.
+Before Claude processes your prompt, clauditor checks two things:
+
+1. **Waste factor** — if the session is burning too much quota, it blocks with exit code 2.
+2. **"Continue" detection** — if you type "continue", "resume", "pick up where I left off", etc., it blocks with your saved session choices and copyable prompts.
 
 ```
 Waste factor = current tokens/turn ÷ baseline tokens/turn
@@ -77,21 +99,25 @@ Waste factor = current tokens/turn ÷ baseline tokens/turn
  10x = blocked — start fresh
 ```
 
-At 10x waste (configurable), clauditor blocks the prompt. You see the message. Claude sees it. No tokens are burned on the blocked turn.
-
 ### `PostToolUse` — blocks during autonomous work
 
 When Claude is working autonomously (editing files, running commands), there's no user prompt to intercept. The PostToolUse hook catches this — after each tool call, it checks the waste factor and blocks if too high.
 
-Uses exit code 2, which Claude Code treats as a blocking error. Claude acknowledges it and stops.
+Uses exit code 2, which Claude Code treats as a blocking error. Claude acknowledges it, writes a handoff summary, and stops.
+
+Also detects: cache degradation, token spikes, resume anomalies, edit thrashing, and **buggy Claude Code versions** (2.1.69-2.1.89 have a known cache bug that burns 10-20x tokens).
 
 ### `PreCompact` — saves context before compaction
 
-Fires at the exact moment before Claude Code compacts your context. Saves session state (branch, files modified, turn count) to `~/.clauditor/last-session.md`. No guessing about context thresholds.
+Fires at the exact moment before Claude Code compacts your context. Saves session state as a fallback in case PostCompact doesn't fire.
+
+### `PostCompact` — captures Claude's own session summary
+
+Fires after compaction. Receives `compact_summary` — Claude's own LLM-generated summary of the session, created while it still had full context. This is dramatically richer than mechanical extraction because Claude knows the reasoning, blockers, and plan.
 
 ### `SessionStart` — injects previous session context
 
-When you start a new session, clauditor reads the saved state from `~/.clauditor/last-session.md` and injects it into Claude's context. Claude picks up where you left off.
+When you start a new session, clauditor reads saved handoff files for this project and injects them into Claude's context. If multiple sessions exist (last 24h), Claude presents the choice.
 
 ### `Stop` — blocks infinite loops
 
@@ -102,17 +128,22 @@ When Claude repeats the same tool call 3+ times with identical input and output,
 From a real user's Claude Code usage over 7 days:
 
 ```
-Session                                  Turns  Tokens/turn   Waste
-─────────────────────────────────────────────────────────────────────
-api-service (feat/variable-agent)          889     395k/turn    16x   ← clauditor blocked this
-api-service (feat/variable-agent)            5      20k/turn     1x   ← fresh session after block
-api-service (feat/agentic-file)            779     168k/turn    13x
-api-service (fix/delete-test-cases)        321     116k/turn     9x
-api-service (dev)                          300     137k/turn    10x
-api-service (fix/file-assertion)           216      99k/turn     8x
-```
+  TURNS  BASE   NOW   WASTE  TOKENS
+  ──────────────────────────────────────────────────────────
+    317   21k  417k  20.1x    73M  ████████████████████
+    576   28k  401k  14.5x   116M  ███████████████
+    172   23k  249k    11x    25M  ███████████
+    164   26k  220k   8.6x    21M  █████████
+    230   28k  218k   7.8x    31M  ████████
+    ...
+  ──────────────────────────────────────────────────────────
+  37 sessions · 418M tokens total
+  15 sessions burned 5x+ more quota than necessary
 
-Every session over 100 turns was burning 8-16x more quota than necessary. clauditor would have rotated each one, reducing total quota usage by an estimated 5-10x.
+  clauditor impact
+  With rotation on all sessions: 157M tokens instead of 418M
+  Potential savings: 261M tokens (62% less quota)
+```
 
 ## Dashboard (optional)
 
@@ -121,46 +152,39 @@ clauditor watch
 ```
 
 ```
-── clauditor ──  4 sessions + 24 subagents (last 12h)
+── clauditor ──  4 sessions + 3 subagents (last 12h)
 
- api-service (feat/variable-agent)  opus-4-6 · 33 turns
+ LAST 7 DAYS
+ 37 sessions · 15 burned 5x+ quota
+ Worst: api/service (317 turns, 20.1x waste — 21k→417k/turn)
+ With rotation: 157M tokens instead of 418M (62% savings)
 
- Waste factor: 2x  efficient
- ███░░░░░░░░░░░░░░░░░░░░░░░░░░░
- Started at 20k/turn → now 41k/turn (2x more quota per turn)
+ api-service (feat/variable-agent)  opus-4-6 · 239 turns
 
- Cache: 99%  Turns: 33  ~$4 API est.
+ Waste factor: 8x  BLOCKED — start a fresh session
+ ██████████████████████████████
+ Started at 20k/turn → now 153k/turn (8x more quota per turn)
 
- OTHER SESSIONS
- ⟲ api-service (feat/variable-agent)    902 turns  400k/turn
- · api-service (feat/agentic-file)        2 turns   20k/turn
- ✓ api-service (feat/agentic-file)      209 turns  193k/turn
-
- LAST ACTIONS
- just now   📦 BLOCKED tool result — 16x waste
- 8m ago     📦 BLOCKED prompt — 15x waste factor
-
- q to quit
+ Cache: 98%  Turns: 239  ~$64 API est.
 ```
 
-The bar fills up as your session grows. At 10x, clauditor blocks.
-
-## Session history
+## Peak vs off-peak analysis
 
 ```bash
-clauditor sessions
+clauditor time
 ```
 
-See where your tokens went:
+Shows token costs by hour of day to detect if peak hours burn more quota:
 
 ```
-Sessions from last 7 days (70 total):
-────────────────────────────────────────────────────────────────────────
-  api-service (feat/variable-agent)  opus-4-6    889 turns  cache: 100%  ~$645
-    ⚠ 16x waste — blocked by clauditor
-  api-service (feat/variable-agent)  opus-4-6      5 turns  cache: 99%     ~$1
-  api-service (feat/agentic-file)    opus-4-6    779 turns  cache: 100%  ~$563
-  api-service (fix/delete-test-cases) opus-4-6   321 turns  cache: 100%   ~$68
+  Token Usage by Hour — last 7 days
+  ──────────────────────────────────────────────────────────
+  10:00    98k/turn   304 turns  cache  92%  ███████████
+  14:00   124k/turn   289 turns  cache  96%  ██████████████
+  18:00   164k/turn   275 turns  cache  98%  ██████████████████
+  ──────────────────────────────────────────────────────────
+  Peak (9am-5pm):    114k avg tokens/turn
+  Off-peak:          154k avg tokens/turn
 ```
 
 ## All commands
@@ -238,36 +262,44 @@ Created automatically on `clauditor install`. Edit to customize.
 
 ## How it saves context
 
-When rotation triggers, clauditor extracts rich context from the session transcript and saves to `~/.clauditor/last-session.md`:
+clauditor uses two methods to save session context, depending on what triggered the save:
 
-```markdown
-# Last Session (saved by clauditor)
+### PostCompact (preferred) — Claude's own summary
 
-- **Branch:** feat/variable-agent
-- **Project:** /Users/alice/projects/api-service
-- **Session size:** 108 turns, 91k tokens/turn
-- **Waste factor:** 5x
-- **Files modified:** VariableAgentEvaluator.cs, DateTimeTools.cs, AIActionExecutor.cs
-- **Files read:** Program.cs, appsettings.json, VariableAgent.cs
+When Claude Code compacts your session, the `PostCompact` hook captures `compact_summary` — Claude's own LLM-generated summary, created while it still had full context. This includes reasoning, decisions, blockers, and plans that no mechanical extraction can capture.
 
-## Original Task
-Add a new evaluation mode to the VariableAgentEvaluator that supports generate.csv format
+### Rotation block (fallback) — mechanical extraction
 
-## Commits Made
-- feat: add generation dataset support to VariableAgentEvaluator
-- fix: handle regex matching for multi-format expected outputs
+When clauditor blocks a session (waste factor too high), it extracts structured data from the JSONL transcript:
 
-## Key Commands & Results
-- dotnet test --filter VariableAgent
-- → Passed! - Failed: 0, Passed: 91
+- Original task (first user message)
+- Last 3 user messages (recent decisions)
+- Last assistant message (often contains the plan/next steps)
+- Git commits made during the session
+- Key commands and results (tests, builds)
+- Files modified and read
 
-## Where We Left Off
-Next steps:
-1. Building the model-agnostic tool-use loop in MultiLLMClient
-2. Migrating VariableAgentRunner to use it
+### Per-session storage
+
+Each handoff is saved as a separate timestamped file:
+
+```
+~/.clauditor/sessions/<encoded-project-path>/<timestamp>.md
 ```
 
-On the next `SessionStart`, this is injected into Claude's context. Claude reads it and picks up where you left off — including the plan from the previous session. No CLAUDE.md modification, no git noise, no extra tokens per turn.
+Multiple sessions in the same project don't overwrite each other. Files older than 24h are cleaned up automatically. A legacy `~/.clauditor/last-session.md` is also written for backward compatibility.
+
+### Session resume flow
+
+1. clauditor blocks your session (or `/compact` fires)
+2. Context is saved to per-session file
+3. You open a new session and type "continue"
+4. clauditor blocks with your saved sessions and copyable prompts
+5. You paste the prompt — Claude reads the file and picks up where you left off
+
+## Version-aware warnings
+
+clauditor detects if your sessions ran on Claude Code versions 2.1.69-2.1.89, which have a [confirmed prompt caching bug](https://github.com/anthropics/claude-code/issues/34629) that causes 10-20x token consumption. The warning appears in `clauditor report` and via real-time hooks.
 
 ## Technical details
 
@@ -289,14 +321,16 @@ After 200 turns, the history alone can be 200k+ tokens. A fresh session resets t
 | Baseline | First 5 turns of session | Average tokens/turn |
 | Current | Last 5 turns of session | Average tokens/turn |
 | Waste factor | Derived | `current ÷ baseline` |
+| Cache ratio | JSONL `usage` field | `cache_read ÷ (input + cache_read + cache_create)` |
 
 **Hook communication:**
 
 | Hook | Mechanism | Why |
 |---|---|---|
-| `UserPromptSubmit` | `decision: "block"` | Stops prompt before processing |
+| `UserPromptSubmit` | Exit code 2 + stderr | Hard block — stops prompt, shows message |
 | `PostToolUse` | Exit code 2 + stderr | Blocking error — Claude acknowledges and stops |
-| `PreCompact` | File write | Saves state at exact compaction moment |
+| `PreCompact` | File write | Saves fallback state at compaction moment |
+| `PostCompact` | File write | Captures Claude's own LLM summary |
 | `SessionStart` | `additionalContext` | Injects previous session state |
 | `Stop` | `decision: "block"` | Prevents infinite loops |
 
@@ -307,6 +341,7 @@ After 200 turns, the history alone can be 200k+ tokens. A fresh session resets t
 - **Cache reads may or may not count toward quota.** The exact quota accounting for Max plan subscribers is not published.
 - **Web sessions not supported.** Only CLI and IDE extensions write local JSONL files.
 - **Per-device only.** Sessions don't sync across machines.
+- **VS Code UserPromptSubmit limitation.** The "continue" prompt block works in CLI but [may not fire in VS Code](https://github.com/anthropics/claude-code/issues/17277). Context is still injected via SessionStart.
 
 ## Development
 
@@ -314,7 +349,7 @@ After 200 turns, the history alone can be 200k+ tokens. A fresh session resets t
 git clone https://github.com/IyadhKhalfallah/clauditor.git
 cd clauditor
 npm install
-npm test        # 68 tests
+npm test        # 131 tests
 npm run build
 npm link        # makes `clauditor` available globally
 ```


### PR DESCRIPTION
Updates for everything shipped since the initial README:
- 6 hooks (added PostCompact for Claude's own session summary)
- Per-session storage with multi-session choice on continue
- "continue" prompt block with copyable prompts
- PostCompact vs mechanical extraction explained
- Version-aware cache bug warnings (2.1.69-2.1.89)
- clauditor time (peak vs off-peak analysis)
- npx install support
- Audit-only mode
- Compatibility with Headroom/MemStack/Workspace Optimizer
- VS Code UserPromptSubmit limitation documented
- Real data from clauditor report output
- 131 tests (was 68)
- Hook table updated (exit code 2 for UserPromptSubmit)