### PR TITLE
fix: don't block "continue" in existing sessions

### DIFF
--- a/src/hooks/continue-detect.test.ts
+++ b/src/hooks/continue-detect.test.ts
@@ -88,3 +88,15 @@ describe('continue prompt detection', () => {
     }
   })
 })
+
+describe('existing session detection', () => {
+  it('detects assistant turns in transcript', () => {
+    const transcriptWithTurns = '{"type":"user","message":{"content":"hello"}}\n{"type":"assistant","message":{"role":"assistant","usage":{"input_tokens":100}}}'
+    expect(transcriptWithTurns.includes('"type":"assistant"')).toBe(true)
+  })
+
+  it('detects no assistant turns in empty transcript', () => {
+    const emptyTranscript = '{"type":"user","message":{"content":"hello"}}'
+    expect(emptyTranscript.includes('"type":"assistant"')).toBe(false)
+  })
+})

--- a/src/hooks/user-prompt-submit.ts
+++ b/src/hooks/user-prompt-submit.ts
@@ -265,6 +265,19 @@ function checkContinuePrompt(hookInput: UserPromptSubmitInput): { decision: stri
   const prompt = hookInput.prompt || ''
   if (!isContinuePrompt(prompt)) return null
 
+  // Don't block if this is an existing session (has assistant turns).
+  // The user might be saying "continue here" after dismissing a rotation block,
+  // meaning "keep working in this session" — not "load a handoff."
+  if (hookInput.transcript_path) {
+    try {
+      const transcript = readFileSync(hookInput.transcript_path, 'utf-8')
+      const hasAssistantTurns = transcript.includes('"type":"assistant"')
+      if (hasAssistantTurns) return null
+    } catch {
+      // Can't read transcript — proceed with block (safe default for new sessions)
+    }
+  }
+
   const handoffs = readRecentHandoffs(hookInput.cwd || null)
   if (handoffs.length === 0) return null
 


### PR DESCRIPTION
## Summary
"continue here" after dismissing a rotation block was triggering the handoff
block a second time. Now checks if the transcript has assistant turns — if so,
skips the continue-prompt block.

## Behavior
- Fresh session + "continue" → block with handoff choices (correct)
- Existing session + "continue here" → passes through (fixed)

## Test plan
- [x] 193 tests pass (2 new tests for transcript detection)
- [x] Verified: existing transcript → exit 0, fresh session → exit 2
