### PR TITLE
fix: cross-project session handoffs + error logging

### DIFF
--- a/src/features/session-state.per-session.test.ts
+++ b/src/features/session-state.per-session.test.ts
@@ -152,19 +152,23 @@ describe('per-session handoff storage', () => {
     expect(handoffs[0].content).toContain('Legacy handoff')
   })
 
-  it('isolates handoffs by project (cwd)', async () => {
+  it('returns handoffs from all projects (global scan)', async () => {
     const mod = await importFresh(tempDir)
 
     mod.saveSessionState(makeBaseData({ cwd: '/home/user/project-a', originalTask: 'Project A task' }))
     mod.saveSessionState(makeBaseData({ cwd: '/home/user/project-b', originalTask: 'Project B task' }))
 
-    const handoffsA = mod.readRecentHandoffs('/home/user/project-a')
-    expect(handoffsA.length).toBe(1)
-    expect(handoffsA[0].content).toContain('Project A task')
+    // readRecentHandoffs now returns all projects regardless of cwd
+    const handoffs = mod.readRecentHandoffs()
+    expect(handoffs.length).toBe(2)
+    const contents = handoffs.map((h: { content: string }) => h.content)
+    expect(contents.some((c: string) => c.includes('Project A task'))).toBe(true)
+    expect(contents.some((c: string) => c.includes('Project B task'))).toBe(true)
 
-    const handoffsB = mod.readRecentHandoffs('/home/user/project-b')
-    expect(handoffsB.length).toBe(1)
-    expect(handoffsB[0].content).toContain('Project B task')
+    // Project metadata is extracted from content
+    const projects = handoffs.map((h: { project: string | null }) => h.project)
+    expect(projects).toContain('/home/user/project-a')
+    expect(projects).toContain('/home/user/project-b')
   })
 
   it('marks PostCompact files vs mechanical extraction correctly', async () => {

--- a/src/features/session-state.ts
+++ b/src/features/session-state.ts
@@ -111,7 +111,9 @@ export function saveSessionState(data: SessionStateData): void {
 
     // Also write to legacy path for backward compat
     writeFileSync(LEGACY_SESSION_FILE, sections.join('\n'))
-  } catch {}
+  } catch (err) {
+    process.stderr.write(`clauditor: failed to save session state: ${err}\n`)
+  }
 }
 
 /**
@@ -134,7 +136,9 @@ export function savePostCompactSummary(summary: string, cwd: string | null): voi
     const timestamp = Date.now()
     writeFileSync(resolve(dir, `${timestamp}.md`), content)
     writeFileSync(LEGACY_SESSION_FILE, content)
-  } catch {}
+  } catch (err) {
+    process.stderr.write(`clauditor: failed to save PostCompact summary: ${err}\n`)
+  }
 }
 
 export interface HandoffFile {
@@ -142,6 +146,8 @@ export interface HandoffFile {
   content: string
   timestamp: number
   isPostCompact: boolean
+  /** Project path extracted from handoff content (e.g. "/Users/.../my-project") */
+  project: string | null
 }
 
 /**
@@ -207,54 +213,75 @@ export function extractHandoffDescription(handoff: HandoffFile): string {
 }
 
 /**
- * Read recent handoff files for a given cwd (last 24 hours).
+ * Read recent handoff files across ALL projects (last 24 hours).
+ * Scans every subdirectory under ~/.clauditor/sessions/ so that
+ * cross-project handoffs are always visible.
  * Returns them sorted by timestamp, most recent first.
  */
-export function readRecentHandoffs(cwd: string | null): HandoffFile[] {
+export function readRecentHandoffs(_cwd?: string | null): HandoffFile[] {
   const results: HandoffFile[] = []
   const cutoff = Date.now() - MAX_HANDOFF_AGE_MS
 
-  // Check per-session directory
-  const dir = getSessionsDir(cwd)
+  // Scan all project subdirectories under SESSIONS_DIR
+  const dirsToScan: string[] = []
   try {
-    const files = readdirSync(dir).filter(f => f.endsWith('.md'))
-    for (const file of files) {
-      const filePath = resolve(dir, file)
-      try {
-        // Use filename timestamp (more reliable than mtime for age check)
-        const fileTs = parseInt(basename(file, '.md'), 10)
-        const stat = statSync(filePath)
-        const effectiveTs = isNaN(fileTs) ? stat.mtimeMs : fileTs
-
-        if (effectiveTs < cutoff) {
-          // Clean up old files
-          try { unlinkSync(filePath) } catch {}
-          continue
-        }
-        const content = readFileSync(filePath, 'utf-8')
-        results.push({
-          path: filePath,
-          content,
-          timestamp: effectiveTs,
-          isPostCompact: content.includes('PostCompact'),
-        })
-      } catch {}
+    const entries = readdirSync(SESSIONS_DIR, { withFileTypes: true })
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        dirsToScan.push(resolve(SESSIONS_DIR, entry.name))
+      }
     }
   } catch {
-    // Directory doesn't exist yet
+    // Sessions dir doesn't exist yet
   }
 
-  // Fallback: check legacy file if no per-session files found
+  // Also scan the root sessions dir (for files saved without cwd)
+  dirsToScan.push(SESSIONS_DIR)
+
+  for (const dir of dirsToScan) {
+    try {
+      const files = readdirSync(dir).filter(f => f.endsWith('.md'))
+      for (const file of files) {
+        const filePath = resolve(dir, file)
+        try {
+          const fileTs = parseInt(basename(file, '.md'), 10)
+          const st = statSync(filePath)
+          const effectiveTs = isNaN(fileTs) ? st.mtimeMs : fileTs
+
+          if (effectiveTs < cutoff) {
+            try { unlinkSync(filePath) } catch {}
+            continue
+          }
+          const content = readFileSync(filePath, 'utf-8')
+
+          // Extract project name from content for labeling
+          const projectMatch = content.match(/\*\*Project:\*\*\s*(.+)/)
+          const project = projectMatch ? projectMatch[1].trim() : null
+
+          results.push({
+            path: filePath,
+            content,
+            timestamp: effectiveTs,
+            isPostCompact: content.includes('PostCompact'),
+            project,
+          })
+        } catch {}
+      }
+    } catch {}
+  }
+
+  // Fallback: check legacy file if nothing found
   if (results.length === 0) {
     try {
-      const stat = statSync(LEGACY_SESSION_FILE)
-      if (stat.mtimeMs >= cutoff) {
+      const st = statSync(LEGACY_SESSION_FILE)
+      if (st.mtimeMs >= cutoff) {
         const content = readFileSync(LEGACY_SESSION_FILE, 'utf-8')
         results.push({
           path: LEGACY_SESSION_FILE,
           content,
-          timestamp: stat.mtimeMs,
+          timestamp: st.mtimeMs,
           isPostCompact: content.includes('PostCompact'),
+          project: null,
         })
       }
     } catch {}

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -57,18 +57,25 @@ async function buildSessionStartContext(
 
     // Inject session handoff(s) if available
     const { readRecentHandoffs, extractHandoffDescription } = await import('../features/session-state.js')
-    const handoffs = readRecentHandoffs(cwd || null)
+    const handoffs = readRecentHandoffs()
+
+    // Helper: short project label for cross-project sessions
+    const projectLabel = (h: { project: string | null }): string => {
+      if (!h.project || h.project === cwd) return ''
+      const name = h.project.split('/').pop() || h.project
+      return ` [${name}]`
+    }
 
     if (handoffs.length === 1) {
       // Single recent handoff — inject it directly
-      // Frame as something Claude MUST relay before doing anything
       const h = handoffs[0]
       const timeAgo = Math.round((Date.now() - h.timestamp) / 60000)
       const timeStr = timeAgo < 60 ? `${timeAgo}m ago` : `${Math.round(timeAgo / 60)}h ago`
+      const label = projectLabel(h)
 
       parts.push(
         `⚠️ BEFORE doing ANYTHING else, you MUST show this message to the user EXACTLY:\n\n` +
-        `"clauditor: I have context from your previous session (saved ${timeStr}). ` +
+        `"clauditor: I have context from your previous session${label} (saved ${timeStr}). ` +
         `I can see what you were working on. Want me to continue from there, or are you starting something new?"\n\n` +
         `Wait for the user to respond before taking any action.\n\n` +
         `Here is the saved context for reference:\n\n` +
@@ -80,13 +87,14 @@ async function buildSessionStartContext(
         const timeAgo = Math.round((Date.now() - h.timestamp) / 60000)
         const timeStr = timeAgo < 60 ? `${timeAgo}m ago` : `${Math.round(timeAgo / 60)}h ago`
         const description = extractHandoffDescription(h)
+        const label = projectLabel(h)
 
-        return `${i + 1}. (${timeStr}) ${description}`
+        return `${i + 1}. (${timeStr}) ${description}${label}`
       }).join('\n')
 
       parts.push(
         `⚠️ BEFORE doing ANYTHING else, you MUST show this message to the user EXACTLY:\n\n` +
-        `"clauditor: I found ${handoffs.length} recent sessions for this project:\n\n` +
+        `"clauditor: I found ${handoffs.length} recent sessions:\n\n` +
         options + `\n\n` +
         `Which one would you like to continue, or are you starting something new?"\n\n` +
         `Wait for the user to choose before taking any action. Do NOT pick one yourself.\n\n` +

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -150,7 +150,9 @@ function captureRotationHandoff(input: StopHookInput): void {
       session: input.session_id.slice(0, 8),
       message: `Stop hook: captured Claude's rotation handoff summary (${msg.length} chars)`,
     }).catch(() => {})
-  } catch {}
+  } catch (err) {
+    process.stderr.write(`clauditor: failed to save rotation handoff: ${err}\n`)
+  }
 }
 
 function hashValue(value: unknown): string {

--- a/src/hooks/user-prompt-submit.ts
+++ b/src/hooks/user-prompt-submit.ts
@@ -278,8 +278,16 @@ function checkContinuePrompt(hookInput: UserPromptSubmitInput): { decision: stri
     }
   }
 
-  const handoffs = readRecentHandoffs(hookInput.cwd || null)
+  const handoffs = readRecentHandoffs()
   if (handoffs.length === 0) return null
+
+  // Helper: short project label for cross-project sessions
+  const currentCwd = hookInput.cwd || null
+  const projectLabel = (h: typeof handoffs[0]): string => {
+    if (!h.project || h.project === currentCwd) return ''
+    const name = h.project.split('/').pop() || h.project
+    return ` [${name}]`
+  }
 
   if (handoffs.length === 1) {
     const h = handoffs[0]
@@ -287,6 +295,7 @@ function checkContinuePrompt(hookInput: UserPromptSubmitInput): { decision: stri
     const timeStr = timeAgo < 60 ? `${timeAgo}m ago` : `${Math.round(timeAgo / 60)}h ago`
     const desc = extractHandoffDescription(h)
     const shortPath = shortenPath(h.path)
+    const label = projectLabel(h)
 
     return {
       decision: 'block',
@@ -294,7 +303,7 @@ function checkContinuePrompt(hookInput: UserPromptSubmitInput): { decision: stri
         `\n╔══════════════════════════════════════════════════════════════╗\n` +
         `║  clauditor: Previous session found (saved ${timeStr})        ║\n` +
         `╚══════════════════════════════════════════════════════════════╝\n\n` +
-        `  ${desc}\n\n` +
+        `  ${desc}${label}\n\n` +
         `To continue, copy and paste this:\n\n` +
         `  read ${shortPath} and continue where I left off\n\n` +
         `Or type something else to start fresh.`,
@@ -307,8 +316,9 @@ function checkContinuePrompt(hookInput: UserPromptSubmitInput): { decision: stri
     const timeStr = timeAgo < 60 ? `${timeAgo}m ago` : `${Math.round(timeAgo / 60)}h ago`
     const desc = extractHandoffDescription(h)
     const shortPath = shortenPath(h.path)
+    const label = projectLabel(h)
 
-    return `  ${i + 1}. (${timeStr}) ${desc}\n     → read ${shortPath} and continue where I left off`
+    return `  ${i + 1}. (${timeStr}) ${desc}${label}\n     → read ${shortPath} and continue where I left off`
   })
 
   const lines = choices.join('\n\n')


### PR DESCRIPTION
## Summary

- **Cross-project session handoffs**: `readRecentHandoffs()` now scans all project directories instead of only the current cwd. Switching between related projects no longer makes session handoffs invisible.
- **Project labels**: Cross-project sessions show `[project-name]` labels in both the "continue" prompt and session-start injection.
- **Error logging**: Critical `catch {}` blocks that silently swallowed session save and rotation handoff failures now log to stderr.

## What changed

| File | Change |
|------|--------|
| `session-state.ts` | Global scan in `readRecentHandoffs()`, `project` field on `HandoffFile`, save error logging |
| `session-state.per-session.test.ts` | Updated test for global scan behavior |
| `user-prompt-submit.ts` | Project labels in continue flow |
| `session-start.ts` | Project labels in session injection |
| `stop.ts` | Error logging on rotation handoff save |

## Test plan

- [x] 211/211 tests passing
- [x] Build passes (TypeScript strict mode)
- [ ] Manual: save a session in project A, open claude in project B, type "continue" — session from A should appear with `[project-a]` label
- [ ] Manual: verify stderr output when session save fails (e.g. read-only filesystem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)