### PR TITLE
fix: push error fixes to hub, not just errors

### DIFF
--- a/src/features/error-index.ts
+++ b/src/features/error-index.ts
@@ -191,7 +191,13 @@ export function clearCommandBuffer(cwd: string): void {
   writeCommandBuffer(cwd, [])
 }
 
-export function recordFix(cwd: string, command: string): void {
+export interface FixResult {
+  command: string
+  error: string
+  fix: string
+}
+
+export function recordFix(cwd: string, command: string): FixResult | null {
   const errors = readErrorIndex(cwd)
   const baseCmd = extractBaseCommand(command)
   const now = Date.now()
@@ -205,7 +211,7 @@ export function recordFix(cwd: string, command: string): void {
     )
     .sort((a, b) => (b.lastErrorMs || 0) - (a.lastErrorMs || 0))[0]
 
-  if (!unfixed) return
+  if (!unfixed) return null
 
   // Use intermediate commands as the fix (what ran between failure and success)
   const buffer = readCommandBuffer(cwd)
@@ -225,6 +231,8 @@ export function recordFix(cwd: string, command: string): void {
   unfixed.confidence = Math.min(1.0, unfixed.confidence + 0.15)
   writeErrors(cwd, errors)
   writeCommandBuffer(cwd, [])
+
+  return { command: unfixed.command, error: unfixed.error, fix: unfixed.fix! }
 }
 
 /**

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -114,7 +114,20 @@ async function processToolResult(input: PostToolUseHookInput): Promise<HookDecis
       }
     } else if (cwd && typeof input.tool_input?.command === 'string') {
       // Command succeeded — check if it's a fix for a recent error
-      try { recordFix(cwd, input.tool_input.command) } catch {}
+      try {
+        const fixResult = recordFix(cwd, input.tool_input.command)
+        if (fixResult) {
+          // Push the fix to the hub so team members learn from it
+          hubPush(cwd, [{
+            type: 'error',
+            content: {
+              command: fixResult.command,
+              error_message: fixResult.error,
+              fix: fixResult.fix,
+            },
+          }])
+        }
+      } catch {}
     }
 
     // Push errors to hub (local recording already handled above)


### PR DESCRIPTION
## Summary

Fixes missing fix data in the hub. Previously only the initial error was pushed — when a fix was discovered later, it was saved locally but never sent to the hub.

### Before

Hub receives: `{command: "npm run build", error_message: "Module not found"}`
Fix discovered locally but never pushed. Team members see errors without solutions.

### After

Hub receives: `{command: "npm run build", error_message: "Module not found", fix: "npx drizzle-kit push"}`
The hub consolidation can now create knowledge entries with actual fixes.

### Changes

- `recordFix()` now returns `FixResult | null` instead of `void`
- PostToolUse pushes the fix fragment to the hub when a fix is discovered

### Test plan

- [x] 305 tests passing
- [x] Build passes