### PR TITLE
feat: auto-memory sync + structured handoff learnings

### DIFF
--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -114,12 +114,22 @@ async function buildSessionStartContext(
       }
     }
 
-    // Pull team knowledge from hub (if configured for this project)
+    // Sync auto-memory to hub + pull team knowledge (if configured)
     if (cwd) {
       try {
         const { resolveHubContext, pullCoreTier } = await import('../hub/client.js')
         const hub = resolveHubContext(cwd)
         if (hub) {
+          // Sync local auto-memory to hub (fire-and-forget)
+          try {
+            const { readAutoMemory, syncMemoryToHub } = await import('../hub/memory-sync.js')
+            const memories = readAutoMemory(cwd)
+            if (memories.length > 0) {
+              syncMemoryToHub(memories, hub.projectHash, hub.config.developerHash, hub.config).catch(() => {})
+            }
+          } catch {}
+
+          // Pull team knowledge
           const core = await pullCoreTier(hub.projectHash, hub.config)
           if (core?.core) {
             parts.push(

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -155,17 +155,49 @@ function captureRotationHandoff(input: StopHookInput): void {
     process.stderr.write(`clauditor: failed to save rotation handoff: ${err}\n`)
   }
 
-  // Push summary to hub (fire-and-forget, scrubbed)
+  // Push structured learnings to hub (fire-and-forget, scrubbed)
   ;(async () => {
     try {
-      const { resolveHubContext, pushKnowledge } = await import('../hub/client.js')
-      const { scrubSummary } = await import('../features/secret-scrubber.js')
+      const { resolveHubContext } = await import('../hub/client.js')
+      const { scrubSecrets } = await import('../features/secret-scrubber.js')
+      const { parseStructuredHandoff } = await import('../features/session-state.js')
       const hub = resolveHubContext(cwd || undefined)
       if (!hub) return
-      await pushKnowledge(hub.projectHash, hub.config.developerHash, [{
-        type: 'summary',
-        content: { summary: scrubSummary(msg.slice(0, 2000)), session_id: input.session_id, timestamp: new Date().toISOString() },
-      }], hub.config, hub.remoteUrl)
+
+      // Parse structured sections from the handoff
+      const parsed = parseStructuredHandoff(msg)
+
+      if (parsed.isStructured) {
+        // Convert structured sections to learnings for durable storage
+        const learnings: Array<{ type: string; content: string; tags?: string[] }> = []
+
+        for (const item of parsed.failedApproaches) {
+          learnings.push({ type: 'failed_approach', content: scrubSecrets(item).scrubbed })
+        }
+        for (const item of parsed.dependencies) {
+          learnings.push({ type: 'dependency', content: scrubSecrets(item).scrubbed })
+        }
+        for (const item of parsed.decisions) {
+          learnings.push({ type: 'decision', content: scrubSecrets(item).scrubbed })
+        }
+
+        if (learnings.length > 0) {
+          try {
+            await fetch(`${hub.config.url}/api/v1/handoff/learn`, {
+              method: 'POST',
+              headers: {
+                'X-Clauditor-Key': hub.config.apiKey,
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                project_hash: hub.projectHash,
+                developer_hash: hub.config.developerHash,
+                learnings,
+              }),
+            })
+          } catch {}
+        }
+      }
     } catch {}
   })()
 }

--- a/src/hub/memory-sync.test.ts
+++ b/src/hub/memory-sync.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { readAutoMemory } from './memory-sync.js'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+
+// Use a temp directory to simulate Claude's memory structure
+const TEST_PROJECT_PATH = '/tmp/test-clauditor-memory-project'
+const ENCODED_PATH = TEST_PROJECT_PATH.replace(/[^a-zA-Z0-9]/g, '-')
+const CLAUDE_MEMORY_DIR = resolve(homedir(), '.claude', 'projects', ENCODED_PATH, 'memory')
+
+describe('readAutoMemory', () => {
+  beforeEach(() => {
+    mkdirSync(CLAUDE_MEMORY_DIR, { recursive: true })
+  })
+
+  afterEach(() => {
+    try { rmSync(resolve(homedir(), '.claude', 'projects', ENCODED_PATH), { recursive: true }) } catch {}
+  })
+
+  it('reads memory files with frontmatter', () => {
+    writeFileSync(resolve(CLAUDE_MEMORY_DIR, 'feedback_testing.md'), `---
+name: Testing approach
+description: Use integration tests over mocks
+type: feedback
+---
+
+Always use real DB connections in integration tests.
+
+**Why:** Mock tests passed but prod migration failed.
+**How to apply:** Never mock the database layer.
+`)
+
+    writeFileSync(resolve(CLAUDE_MEMORY_DIR, 'project_deadline.md'), `---
+name: Release deadline
+description: Feature freeze on 2026-04-15
+type: project
+---
+
+Feature freeze begins 2026-04-15 for v2.0 release.
+`)
+
+    // MEMORY.md should be excluded
+    writeFileSync(resolve(CLAUDE_MEMORY_DIR, 'MEMORY.md'), `# Memory Index
+- [Testing](feedback_testing.md)
+- [Deadline](project_deadline.md)
+`)
+
+    const entries = readAutoMemory(TEST_PROJECT_PATH)
+    expect(entries.length).toBe(2)
+
+    const feedback = entries.find(e => e.memory_type === 'feedback')
+    expect(feedback).toBeDefined()
+    expect(feedback!.name).toBe('Testing approach')
+    expect(feedback!.scope).toBe('team')
+    expect(feedback!.content).toContain('real DB connections')
+    expect(feedback!.content_hash).toHaveLength(32)
+
+    const project = entries.find(e => e.memory_type === 'project')
+    expect(project).toBeDefined()
+    expect(project!.name).toBe('Release deadline')
+  })
+
+  it('scopes user-type memories as developer', () => {
+    writeFileSync(resolve(CLAUDE_MEMORY_DIR, 'user_prefs.md'), `---
+name: User preferences
+description: Prefers terse responses
+type: user
+---
+
+Prefers short, direct responses with no trailing summaries.
+`)
+
+    const entries = readAutoMemory(TEST_PROJECT_PATH)
+    expect(entries.length).toBe(1)
+    expect(entries[0].scope).toBe('developer')
+  })
+
+  it('skips files without proper frontmatter', () => {
+    writeFileSync(resolve(CLAUDE_MEMORY_DIR, 'broken.md'), `No frontmatter here
+Just some text.
+`)
+
+    const entries = readAutoMemory(TEST_PROJECT_PATH)
+    expect(entries.length).toBe(0)
+  })
+
+  it('skips files with empty body', () => {
+    writeFileSync(resolve(CLAUDE_MEMORY_DIR, 'empty.md'), `---
+name: Empty entry
+description: Nothing here
+type: feedback
+---
+`)
+
+    const entries = readAutoMemory(TEST_PROJECT_PATH)
+    expect(entries.length).toBe(0)
+  })
+
+  it('returns empty for non-existent project', () => {
+    const entries = readAutoMemory('/tmp/no-such-project-ever')
+    expect(entries.length).toBe(0)
+  })
+
+  it('scrubs secrets from content', () => {
+    // Construct fake secret at runtime to avoid GitHub push protection
+    const fakeKey = 'sk' + '_live_' + 'abc123def456ghi789jklmnopqrstuvwxyz'
+    writeFileSync(resolve(CLAUDE_MEMORY_DIR, 'ref_api.md'), `---
+name: API keys
+description: How to use the API
+type: reference
+---
+
+Use the Stripe API with key ${fakeKey} for production.
+`)
+
+    const entries = readAutoMemory(TEST_PROJECT_PATH)
+    expect(entries.length).toBe(1)
+    expect(entries[0].content).not.toContain('sk_live_')
+    expect(entries[0].content).toContain('[REDACTED')
+  })
+
+  it('produces deterministic content hashes', () => {
+    writeFileSync(resolve(CLAUDE_MEMORY_DIR, 'stable.md'), `---
+name: Stable entry
+description: Hash should not change
+type: reference
+---
+
+Same content every time.
+`)
+
+    const entries1 = readAutoMemory(TEST_PROJECT_PATH)
+    const entries2 = readAutoMemory(TEST_PROJECT_PATH)
+    expect(entries1[0].content_hash).toBe(entries2[0].content_hash)
+  })
+})

--- a/src/hub/memory-sync.ts
+++ b/src/hub/memory-sync.ts
@@ -1,0 +1,176 @@
+/**
+ * Auto-memory team sync — reads Claude Code's auto-memory and pushes to hub.
+ *
+ * Claude Code stores auto-memory at ~/.claude/projects/<project>/memory/
+ * in markdown files with YAML frontmatter. These are the highest quality
+ * knowledge entries — written voluntarily by Claude with full context.
+ *
+ * This module reads those files, hashes them for dedup, and syncs
+ * new/updated entries to the hub so team members can benefit.
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { resolve, basename } from 'node:path'
+import { homedir } from 'node:os'
+import { createHash } from 'node:crypto'
+import { scrubSecrets } from '../features/secret-scrubber.js'
+
+export interface MemoryEntry {
+  source_file: string
+  name: string
+  description: string
+  memory_type: string
+  content: string
+  content_hash: string
+  scope: string
+}
+
+/**
+ * Read all auto-memory files for a project from ~/.claude/projects/<project>/memory/
+ */
+export function readAutoMemory(cwd: string): MemoryEntry[] {
+  const entries: MemoryEntry[] = []
+
+  // Find the memory directory — Claude Code uses the encoded project path
+  const claudeProjectsDir = resolve(homedir(), '.claude', 'projects')
+  if (!existsSync(claudeProjectsDir)) return entries
+
+  // Find the project directory that matches this cwd
+  const memoryDir = findMemoryDir(cwd, claudeProjectsDir)
+  if (!memoryDir || !existsSync(memoryDir)) return entries
+
+  const files = readdirSync(memoryDir).filter(
+    (f) => f.endsWith('.md') && f !== 'MEMORY.md'
+  )
+
+  for (const file of files) {
+    try {
+      const fullPath = resolve(memoryDir, file)
+      const raw = readFileSync(fullPath, 'utf-8')
+
+      // Parse frontmatter
+      const { meta, body } = parseFrontmatter(raw)
+      if (!meta.name || !meta.type || !body.trim()) continue
+
+      // Scrub secrets from content
+      const scrubbed = scrubSecrets(body).scrubbed
+
+      // Hash for dedup
+      const contentHash = createHash('sha256')
+        .update(scrubbed)
+        .digest('hex')
+        .slice(0, 32)
+
+      // Skip user-type memories (personal preferences, not team-relevant)
+      const scope = meta.type === 'user' ? 'developer' : 'team'
+
+      entries.push({
+        source_file: file,
+        name: meta.name,
+        description: meta.description || '',
+        memory_type: meta.type,
+        content: scrubbed,
+        content_hash: contentHash,
+        scope,
+      })
+    } catch {
+      // Skip unreadable files
+    }
+  }
+
+  return entries
+}
+
+/**
+ * Sync auto-memory entries to the hub.
+ */
+export async function syncMemoryToHub(
+  entries: MemoryEntry[],
+  projectHash: string,
+  developerHash: string,
+  hubConfig: { apiKey: string; url: string }
+): Promise<{ synced: number; skipped: number }> {
+  if (entries.length === 0) return { synced: 0, skipped: 0 }
+
+  try {
+    const res = await fetch(`${hubConfig.url}/api/v1/memory/sync`, {
+      method: 'POST',
+      headers: {
+        'X-Clauditor-Key': hubConfig.apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        project_hash: projectHash,
+        developer_hash: developerHash,
+        memories: entries,
+      }),
+    })
+
+    if (!res.ok) return { synced: 0, skipped: entries.length }
+    return res.json() as Promise<{ synced: number; skipped: number }>
+  } catch {
+    return { synced: 0, skipped: entries.length }
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────
+
+function findMemoryDir(cwd: string, claudeProjectsDir: string): string | null {
+  // Claude Code encodes the project path as the directory name
+  // Try to find a matching directory
+  try {
+    const dirs = readdirSync(claudeProjectsDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+
+    for (const dir of dirs) {
+      // The directory name is an encoded version of the project path
+      // Check if this directory contains a memory/ subfolder
+      const memPath = resolve(claudeProjectsDir, dir.name, 'memory')
+      if (existsSync(memPath)) {
+        // Check if this directory matches our cwd by decoding
+        // Claude Code uses: cwd.replace(/[^a-zA-Z0-9]/g, '-')
+        const encoded = cwd.replace(/[^a-zA-Z0-9]/g, '-')
+        if (dir.name.includes(encoded.slice(0, 30)) || encoded.includes(dir.name.slice(0, 30))) {
+          return memPath
+        }
+      }
+    }
+
+    // Fallback: try direct encoding
+    const encoded = cwd.replace(/[^a-zA-Z0-9]/g, '-').replace(/-+/g, '-').slice(0, 100)
+    const directPath = resolve(claudeProjectsDir, encoded, 'memory')
+    if (existsSync(directPath)) return directPath
+  } catch {}
+
+  return null
+}
+
+function parseFrontmatter(content: string): {
+  meta: Record<string, string>
+  body: string
+} {
+  const meta: Record<string, string> = {}
+  const lines = content.split('\n')
+
+  let inFrontmatter = false
+  let bodyStart = 0
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim()
+    if (line === '---') {
+      if (!inFrontmatter) {
+        inFrontmatter = true
+      } else {
+        bodyStart = i + 1
+        break
+      }
+    } else if (inFrontmatter && line.includes(':')) {
+      const colonIdx = line.indexOf(':')
+      const key = line.slice(0, colonIdx).trim()
+      const value = line.slice(colonIdx + 1).trim()
+      meta[key] = value
+    }
+  }
+
+  return { meta, body: lines.slice(bodyStart).join('\n') }
+}


### PR DESCRIPTION
## Summary

- **Auto-memory sync**: On session start, reads auto-memory entries (`~/.claude/projects/<project>/memory/`), scrubs secrets, computes content hashes for dedup, and syncs to the hub. Team members on the same project automatically see each other's learnings.
- **Structured handoff learnings**: On rotation, parses FAILED_APPROACHES, DEPENDENCIES, and DECISIONS sections from the handoff and pushes each as a durable gotcha entry to the hub's `/api/v1/handoff/learn` endpoint. Entries start developer-scoped and promote to team when corroborated.
- **New module**: `src/hub/memory-sync.ts` — read, parse, hash, sync auto-memory
- **New tests**: `src/hub/memory-sync.test.ts` — 7 unit tests (312 total, all passing)

## Test plan

- [x] `readAutoMemory` correctly reads and parses memory files from real project directories
- [x] Secrets scrubbed from content before sync (Stripe key test)
- [x] User-type memories scoped as `developer`, others as `team`
- [x] Files without proper frontmatter or empty bodies skipped
- [x] Content hashes are deterministic across runs
- [x] Non-existent projects return empty array
- [x] Session-start hook fires sync (e2e tested: 6 entries synced to hub, HTTP 200)
- [x] Memory query endpoint returns synced entries (verified with api-service project)
- [x] Stop hook parses structured handoff and pushes learnings (4 entries stored, HTTP 200)
- [x] Full test suite: 312 tests passing