### PR TITLE
fix: skip npm publish when version already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,18 @@ jobs:
       - run: npm run lint
       - run: npm test
       - run: npm run build
+      - name: Check if version already published
+        id: check-npm
+        run: |
+          VERSION="${{ needs.release-please.outputs.version }}"
+          if npm view "@iyadhk/clauditor@${VERSION}" version 2>/dev/null; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${VERSION} already published to npm, skipping publish"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
       - run: npm publish --provenance --access public
+        if: steps.check-npm.outputs.already_published != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Adds a pre-publish check using `npm view` to detect if the version is already on the registry
- Skips `npm publish` if it is, allowing the rest of the workflow (Homebrew update, tweet draft) to proceed
- Makes release workflow re-runs safe after partial failures

## Context
Release 1.27.1 failed during the Homebrew formula update step. Re-running the job then failed at `npm publish` with a 403 because the version was already published. This fix prevents that.

## Test plan
- [ ] Re-run the failed 1.27.1 release after merging — publish should be skipped, Homebrew formula should update
- [ ] Next fresh release should publish normally (check-npm outputs `already_published=false`)