### PR TITLE
feat: hub v2 — sync, hooks, reliability, production hardening

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -213,6 +213,31 @@ program
     const isSSH = !!(process.env.SSH_CONNECTION || process.env.SSH_TTY || process.env.SSH_CLIENT)
     const useDeviceFlow = options.device || isSSH
 
+    // Auto-install hooks if not already installed
+    try {
+      const { existsSync } = await import('node:fs')
+      const { resolve } = await import('node:path')
+      const { homedir } = await import('node:os')
+      const settingsPath = resolve(homedir(), '.claude', 'settings.json')
+      if (existsSync(settingsPath)) {
+        const settings = JSON.parse((await import('node:fs')).readFileSync(settingsPath, 'utf-8'))
+        const hasHooks = settings.hooks && Object.keys(settings.hooks).length > 0
+        if (!hasHooks) {
+          console.log('\n  Setting up clauditor hooks...')
+          const { installHooks } = await import('./install.js')
+          const msgs = await installHooks()
+          msgs.forEach((m: string) => console.log(m))
+        }
+      } else {
+        console.log('\n  Setting up clauditor hooks...')
+        const { installHooks } = await import('./install.js')
+        const msgs = await installHooks()
+        msgs.forEach((m: string) => console.log(m))
+      }
+    } catch {
+      // Non-critical — hooks can be installed manually with `clauditor install`
+    }
+
     if (useDeviceFlow) {
       // Device flow (RFC 8628) — for SSH, headless, or --no-browser
       await loginDeviceFlow(hubUrl, remoteUrl, developerHash)
@@ -226,6 +251,7 @@ async function loginBrowserFlow(hubUrl: string, remoteUrl: string, developerHash
   const { createHash } = await import('node:crypto')
   const { startAuthServer } = await import('./hub/auth-server.js')
   const { setProjectHubConfig } = await import('./config.js')
+  const { getProjectHash } = await import('./hub/git-project.js')
 
   const state = createHash('sha256')
     .update(`${Date.now()}:${Math.random()}`)
@@ -260,7 +286,110 @@ async function loginBrowserFlow(hubUrl: string, remoteUrl: string, developerHash
 
     console.log(`\n  ✓ Logged in to team "${result.teamName}" (${result.plan})`)
     console.log(`  Connected: ${remoteUrl} → ${result.teamName}`)
-    console.log(`\n  Knowledge will sync automatically during sessions on this project.`)
+
+    // Sync local auto-memory + show team brief summary
+    const projectHash = getProjectHash()
+
+    if (projectHash) {
+      // Sync local auto-memory to hub (silent)
+      try {
+        const { readAutoMemory, syncMemoryToHub } = await import('./hub/memory-sync.js')
+        const memories = readAutoMemory(process.cwd())
+        if (memories.length > 0) {
+          const syncResult = await syncMemoryToHub(memories, projectHash, developerHash, { apiKey: result.apiKey, url: hubUrl }, remoteUrl)
+          if (syncResult.synced > 0) {
+            console.log(`  ↑ Synced ${syncResult.synced} local memories to team hub`)
+          }
+        }
+      } catch {}
+
+      // Show brief count (not full entries — could be many)
+      try {
+        const briefRes = await fetch(`${hubUrl}/api/v1/knowledge/brief?project_hash=${projectHash}&max=1`, {
+          headers: { 'X-Clauditor-Key': result.apiKey },
+          signal: AbortSignal.timeout(5000),
+        })
+        if (briefRes.ok) {
+          const briefData = await briefRes.json() as { brief: Array<{ title: string }>; sources?: Record<string, number> }
+          const total = Object.values(briefData.sources || {}).reduce((a, b) => a + b, 0)
+          if (total > 0) {
+            console.log(`  ↓ ${total} team knowledge entries available — will be injected into your sessions`)
+          } else {
+            console.log(`  No team knowledge yet — it will accumulate as you work`)
+          }
+        }
+      } catch {}
+    }
+
+    console.log('')
+
+    // Check if MCP is already configured
+    const mcpBase = 'https://mcp.clauditor.ai'
+    const mcpUrl = `${mcpBase}/mcp?key=${result.apiKey}`
+
+    let mcpAlreadyConfigured = false
+    try {
+      const { readFileSync } = await import('node:fs')
+      const { resolve: resolvePath } = await import('node:path')
+      const { homedir } = await import('node:os')
+      const claudeJson = JSON.parse(readFileSync(resolvePath(homedir(), '.claude.json'), 'utf-8'))
+      mcpAlreadyConfigured = !!claudeJson?.mcpServers?.clauditor
+    } catch {}
+
+    if (mcpAlreadyConfigured) {
+      console.log(`  ✓ MCP already configured`)
+    } else {
+      // Verify MCP server is reachable
+      let mcpAvailable = false
+      try {
+        const verifyRes = await fetch(`${mcpBase}/health`, { signal: AbortSignal.timeout(5000) })
+        if (verifyRes.ok) {
+          mcpAvailable = true
+        }
+      } catch {}
+
+      if (mcpAvailable) {
+        const readline = await import('node:readline')
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+        const answer = await new Promise<string>((resolve) => {
+          rl.question('  Set up MCP so Claude can query team knowledge mid-session? (Y/n) ', (ans) => {
+            rl.close()
+            resolve(ans.trim().toLowerCase())
+          })
+        })
+
+        if (answer !== 'n' && answer !== 'no') {
+          try {
+            const { execSync } = await import('node:child_process')
+            try { execSync('claude mcp remove clauditor 2>/dev/null', { stdio: 'ignore' }) } catch {}
+            execSync(`claude mcp add --transport http -s user clauditor "${mcpUrl}"`, { stdio: 'inherit' })
+            console.log(`  ✓ MCP configured — start a new Claude Code session to use it`)
+          } catch {
+            try {
+              const { readFileSync, writeFileSync } = await import('node:fs')
+              const { resolve: resolvePath } = await import('node:path')
+              const { homedir } = await import('node:os')
+              const settingsPath = resolvePath(homedir(), '.claude', 'settings.json')
+
+              let settings: Record<string, unknown> = {}
+              try { settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) } catch {}
+
+              const mcpServers = (settings.mcpServers || {}) as Record<string, unknown>
+              mcpServers.clauditor = { type: 'http', url: mcpUrl }
+              settings.mcpServers = mcpServers
+              writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n')
+              console.log(`  ✓ MCP configured via settings.json — start a new Claude Code session to use it`)
+            } catch {
+              console.log(`\n  To set up MCP manually, run:`)
+              console.log(`  claude mcp add --transport http -s user clauditor "${mcpUrl}"`)
+            }
+          }
+        } else {
+          console.log(`\n  You can set up MCP later with:`)
+          console.log(`  claude mcp add --transport http -s user clauditor "${mcpUrl}"`)
+        }
+      }
+    }
   } catch (err) {
     console.error(`\n  ✗ ${err instanceof Error ? err.message : err}`)
     process.exit(1)
@@ -299,6 +428,180 @@ async function loginDeviceFlow(hubUrl: string, remoteUrl: string, developerHash:
     process.exit(1)
   }
 }
+
+// ─── clauditor sync ──────────────────────────────────────────────
+
+program
+  .command('sync')
+  .description('Sync local knowledge to the hub (auto-memory, session handoffs, pending queue)')
+  .action(async () => {
+    const { resolveHubContext } = await import('./hub/client.js')
+    const hub = resolveHubContext()
+    if (!hub) {
+      console.error('\n  ✗ Not connected to a hub. Run `clauditor login` first.')
+      process.exit(1)
+    }
+
+    console.log(`\n  Syncing to ${hub.config.teamName || 'hub'}...`)
+
+    let totalPushed = 0
+
+    // 1. Sync auto-memory
+    try {
+      const { readAutoMemory, syncMemoryToHub } = await import('./hub/memory-sync.js')
+      const memories = readAutoMemory(process.cwd())
+      if (memories.length > 0) {
+        const result = await syncMemoryToHub(memories, hub.projectHash, hub.config.developerHash, hub.config, hub.remoteUrl)
+        if (result.synced > 0) {
+          console.log(`  ↑ ${result.synced} auto-memories synced`)
+          totalPushed += result.synced
+        } else {
+          console.log(`  · Auto-memories already up to date`)
+        }
+      } else {
+        console.log(`  · No local auto-memories found`)
+      }
+    } catch (err) {
+      console.error(`  ✗ Auto-memory sync failed: ${err instanceof Error ? err.message : err}`)
+    }
+
+    // 2. Push session handoffs — structured learnings + summaries as team memories
+    try {
+      const { readRecentHandoffs, parseStructuredHandoff } = await import('./features/session-state.js')
+      const { scrubSecrets } = await import('./features/secret-scrubber.js')
+      const { queueAndSend } = await import('./hub/push-queue.js')
+      const { createHash } = await import('node:crypto')
+      const { readFileSync, writeFileSync, mkdirSync } = await import('node:fs')
+      const { resolve } = await import('node:path')
+
+      // Track which handoffs have been synced (by content hash)
+      const syncedFile = resolve(homedir(), '.clauditor', 'synced-handoffs.json')
+      let syncedHashes: string[] = []
+      try { syncedHashes = JSON.parse(readFileSync(syncedFile, 'utf-8')) } catch {}
+
+      const handoffs = readRecentHandoffs(process.cwd())
+      let handoffLearnings = 0
+      let summariesPushed = 0
+      const newHashes: string[] = []
+
+      for (const handoff of handoffs) {
+        const scrubbed = scrubSecrets(handoff.content).scrubbed
+        const contentHash = createHash('sha256').update(scrubbed).digest('hex').slice(0, 16)
+
+        // Skip if already synced
+        if (syncedHashes.includes(contentHash)) continue
+
+        // Push structured learnings if present
+        const parsed = parseStructuredHandoff(handoff.content)
+        if (parsed.isStructured) {
+          const learnings: Array<{ type: string; content: string }> = []
+          for (const item of parsed.failedApproaches) {
+            learnings.push({ type: 'failed_approach', content: scrubSecrets(item).scrubbed })
+          }
+          for (const item of parsed.dependencies) {
+            learnings.push({ type: 'dependency', content: scrubSecrets(item).scrubbed })
+          }
+          for (const item of parsed.decisions) {
+            learnings.push({ type: 'decision', content: scrubSecrets(item).scrubbed })
+          }
+          for (const item of parsed.whatSurprisedMe) {
+            learnings.push({ type: 'surprise', content: scrubSecrets(item).scrubbed })
+          }
+          for (const item of parsed.gotchas) {
+            learnings.push({ type: 'gotcha', content: scrubSecrets(item).scrubbed })
+          }
+
+          if (learnings.length > 0) {
+            await queueAndSend(
+              `${hub.config.url}/api/v1/handoff/learn`,
+              { 'X-Clauditor-Key': hub.config.apiKey, 'Content-Type': 'application/json' },
+              {
+                project_hash: hub.projectHash,
+                developer_hash: hub.config.developerHash,
+                project_name: hub.remoteUrl,
+                learnings,
+              }
+            )
+            handoffLearnings += learnings.length
+          }
+        }
+
+        // Push full summary as team memory (direct fetch so we can report errors)
+        if (scrubbed.length >= 100) {
+          const filename = handoff.path.split('/').pop()?.replace('.md', '') || 'unknown'
+          const memPayload = {
+            project_hash: hub.projectHash,
+            developer_hash: hub.config.developerHash,
+            project_name: hub.remoteUrl,
+            memories: [{
+              name: `Session summary (${filename})`,
+              description: 'Session summary captured at compaction',
+              memory_type: 'session_summary',
+              content: scrubbed,
+              content_hash: contentHash,
+              source_file: `session_${contentHash}`,
+              scope: 'team',
+            }],
+          }
+          try {
+            const res = await fetch(`${hub.config.url}/api/v1/memory/sync`, {
+              method: 'POST',
+              headers: { 'X-Clauditor-Key': hub.config.apiKey, 'Content-Type': 'application/json' },
+              body: JSON.stringify(memPayload),
+              signal: AbortSignal.timeout(15000),
+            })
+            const data = await res.json() as { synced?: number; skipped?: number; error?: string }
+            if (res.ok && data.synced && data.synced > 0) {
+              summariesPushed++
+            } else {
+              console.error(`  ✗ Summary push failed: ${data.error || `synced=${data.synced} skipped=${data.skipped}`}`)
+            }
+          } catch (err) {
+            console.error(`  ✗ Summary push error: ${err instanceof Error ? err.message : err}`)
+          }
+        }
+
+        newHashes.push(contentHash)
+      }
+
+      // Persist synced hashes
+      if (newHashes.length > 0) {
+        const allHashes = [...new Set([...syncedHashes, ...newHashes])].slice(-200) // keep last 200
+        mkdirSync(resolve(homedir(), '.clauditor'), { recursive: true })
+        writeFileSync(syncedFile, JSON.stringify(allHashes))
+      }
+
+      if (handoffLearnings > 0) {
+        console.log(`  ↑ ${handoffLearnings} structured learnings from handoffs`)
+        totalPushed += handoffLearnings
+      }
+      if (summariesPushed > 0) {
+        console.log(`  ↑ ${summariesPushed} session summary/summaries synced as team memories`)
+        totalPushed += summariesPushed
+      }
+      if (handoffLearnings === 0 && summariesPushed === 0 && handoffs.length === 0) {
+        console.log(`  · No recent session handoffs found`)
+      }
+    } catch (err) {
+      console.error(`  ✗ Handoff sync failed: ${err instanceof Error ? err.message : err}`)
+    }
+
+    // 3. Flush push queue (retries for anything that failed earlier)
+    try {
+      const { flushQueue } = await import('./hub/push-queue.js')
+      const flushed = await flushQueue()
+      if (flushed > 0) {
+        console.log(`  ↑ ${flushed} queued item(s) flushed`)
+        totalPushed += flushed
+      }
+    } catch {}
+
+    if (totalPushed > 0) {
+      console.log(`\n  ✓ Synced ${totalPushed} item(s) to hub`)
+    } else {
+      console.log(`\n  ✓ Everything up to date`)
+    }
+  })
 
 // ─── clauditor stats ─────────────────────────────────────────────
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -589,10 +589,10 @@ program
     // 3. Flush push queue (retries for anything that failed earlier)
     try {
       const { flushQueue } = await import('./hub/push-queue.js')
-      const flushed = await flushQueue()
-      if (flushed > 0) {
-        console.log(`  ↑ ${flushed} queued item(s) flushed`)
-        totalPushed += flushed
+      const { sent } = await flushQueue()
+      if (sent > 0) {
+        console.log(`  ↑ ${sent} queued item(s) flushed`)
+        totalPushed += sent
       }
     } catch {}
 

--- a/src/features/impact-tracker.ts
+++ b/src/features/impact-tracker.ts
@@ -214,5 +214,116 @@ export async function formatImpactStats(stats: ImpactStats): Promise<string> {
       lines.push(`  ${stats.detected.contextOverflows} session${stats.detected.contextOverflows === 1 ? '' : 's'} near context limit`)
   }
 
+  // Knowledge & subagent intelligence (local data)
+  try {
+    const knowledgeLines = await formatKnowledgeStats()
+    if (knowledgeLines.length > 0) {
+      lines.push('')
+      lines.push(...knowledgeLines)
+    }
+  } catch {}
+
   return lines.join('\n')
+}
+
+/**
+ * Gather knowledge and subagent stats from local data.
+ */
+async function formatKnowledgeStats(): Promise<string[]> {
+  const lines: string[] = []
+  const cwd = process.cwd()
+
+  // Error/fix pairs
+  try {
+    const { readdirSync, readFileSync, existsSync } = await import('node:fs')
+    const { resolve } = await import('node:path')
+    const { homedir } = await import('node:os')
+
+    const knowledgeDir = resolve(homedir(), '.clauditor', 'knowledge')
+    if (existsSync(knowledgeDir)) {
+      let totalErrors = 0
+      let totalWithFix = 0
+      const dirs = readdirSync(knowledgeDir, { withFileTypes: true })
+      for (const dir of dirs) {
+        if (!dir.isDirectory()) continue
+        const errorsPath = resolve(knowledgeDir, dir.name, 'errors.json')
+        if (!existsSync(errorsPath)) continue
+        try {
+          const data = JSON.parse(readFileSync(errorsPath, 'utf-8'))
+          const entries = Object.values(data) as Array<{ fix?: string; fixCommands?: string[] }>
+          totalErrors += entries.length
+          totalWithFix += entries.filter(e => e.fix || (e.fixCommands && e.fixCommands.length > 0)).length
+        } catch {}
+      }
+
+      if (totalErrors > 0) {
+        lines.push('  KNOWLEDGE (local)')
+        lines.push('  ─────────────────')
+        lines.push(`  Error/fix pairs:      ${totalErrors} recorded (${totalWithFix} with fixes)`)
+      }
+    }
+  } catch {}
+
+  // Subagent intelligence
+  try {
+    const { scanSubagents, detectPatterns } = await import('./subagent-intel.js')
+    const summary = scanSubagents(cwd)
+
+    if (summary.total > 0) {
+      if (lines.length === 0) {
+        lines.push('  KNOWLEDGE (local)')
+        lines.push('  ─────────────────')
+      }
+      lines.push(`  Subagents spawned:    ${summary.total} across ${new Set(summary.signals.map(s => s.sessionId)).size} sessions`)
+
+      // Top categories
+      const sorted = Object.entries(summary.byCategory)
+        .filter(([, v]) => v > 0)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 4)
+      if (sorted.length > 0) {
+        lines.push(`  Top agent tasks:      ${sorted.map(([k, v]) => `${k} (${v})`).join(', ')}`)
+      }
+
+      // Recurring patterns
+      const patterns = detectPatterns(summary.signals)
+      if (patterns.length > 0) {
+        lines.push(`  Recurring patterns:   ${patterns.length} detected`)
+        for (const p of patterns.slice(0, 2)) {
+          lines.push(`    ${p.count}x "${p.descriptions[0]}"`)
+        }
+      }
+    }
+  } catch {}
+
+  // Hub stats (if configured)
+  try {
+    const { resolveHubContext } = await import('../hub/client.js')
+    const hub = resolveHubContext(cwd)
+    if (hub) {
+      const [memRes, subRes] = await Promise.all([
+        fetch(`${hub.config.url}/api/v1/memory/query?project_hash=${hub.projectHash}`, {
+          headers: { 'X-Clauditor-Key': hub.config.apiKey },
+        }).catch(() => null),
+        fetch(`${hub.config.url}/api/v1/subagents/query?project_hash=${hub.projectHash}`, {
+          headers: { 'X-Clauditor-Key': hub.config.apiKey },
+        }).catch(() => null),
+      ])
+
+      const memData = memRes?.ok ? await memRes.json() as { count: number } : null
+      const subData = subRes?.ok ? await subRes.json() as { summary: { total: number; by_category: Record<string, number> } } : null
+
+      if (memData || subData) {
+        lines.push('')
+        lines.push('  TEAM HUB')
+        lines.push('  ────────')
+        if (memData && memData.count > 0)
+          lines.push(`  Team memories shared: ${memData.count}`)
+        if (subData && subData.summary.total > 0)
+          lines.push(`  Subagent signals:     ${subData.summary.total}`)
+      }
+    }
+  } catch {}
+
+  return lines
 }

--- a/src/features/outcome-tracker.ts
+++ b/src/features/outcome-tracker.ts
@@ -1,0 +1,108 @@
+/**
+ * Outcome Tracker — measures whether injected knowledge actually helped.
+ *
+ * Flow:
+ *   1. Session start: recordInjection(sessionId, entryIds)
+ *   2. Session end (stop hook): reportOutcomes(sessionId, cwd, healthy)
+ *      - If session was healthy → positive outcome for all injected entries
+ *      - If not → no penalty (warning might not have been relevant)
+ *
+ * The positive signal feeds back into the hub's ranking system:
+ * entries with more positive outcomes rank higher in future briefs.
+ *
+ * Persisted to disk because each hook invocation is a separate process.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+
+const TRACKER_DIR = resolve(homedir(), '.clauditor')
+const INJECTIONS_FILE = resolve(TRACKER_DIR, 'injections.json')
+
+interface InjectionRecord {
+  sessionId: string
+  entryIds: string[]
+  timestamp: number
+}
+
+/**
+ * Record which knowledge entry IDs were injected at session start.
+ */
+export function recordInjection(sessionId: string, entryIds: string[]): void {
+  try {
+    mkdirSync(TRACKER_DIR, { recursive: true })
+    const data = readInjections()
+
+    // Keep only last 7 days to avoid bloat
+    const recent = data.filter(d => Date.now() - d.timestamp < 7 * 24 * 60 * 60 * 1000)
+    recent.push({ sessionId, entryIds, timestamp: Date.now() })
+
+    writeFileSync(INJECTIONS_FILE, JSON.stringify(recent.slice(-20), null, 2))
+  } catch {}
+}
+
+/**
+ * Get the injected entry IDs for a session.
+ */
+export function getInjectedIds(sessionId: string): string[] {
+  const data = readInjections()
+  const record = data.find(d => d.sessionId === sessionId)
+  return record?.entryIds || []
+}
+
+/**
+ * Report outcomes for a session to the hub.
+ *
+ * If the session was healthy (no loops, no crashes), all injected
+ * entries get a positive signal. This is the simplest heuristic:
+ * "the knowledge was available and nothing went wrong."
+ *
+ * Over time, entries that are consistently present in healthy sessions
+ * rise in ranking. Entries that are injected but sessions still fail
+ * don't get penalized (maybe the failure was unrelated).
+ */
+export async function reportOutcomes(
+  sessionId: string,
+  cwd: string,
+  sessionHealthy: boolean
+): Promise<number> {
+  const entryIds = getInjectedIds(sessionId)
+  if (entryIds.length === 0) return 0
+
+  // Only report positive outcomes for healthy sessions
+  if (!sessionHealthy) return 0
+
+  try {
+    const { resolveHubContext } = await import('../hub/client.js')
+    const hub = resolveHubContext(cwd)
+    if (!hub) return 0
+
+    const res = await fetch(`${hub.config.url}/api/v1/knowledge/outcome`, {
+      method: 'POST',
+      headers: {
+        'X-Clauditor-Key': hub.config.apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        entry_ids: entryIds,
+        outcome: 'positive',
+      }),
+    })
+
+    if (res.ok) {
+      const data = await res.json() as { updated: number }
+      return data.updated
+    }
+  } catch {}
+
+  return 0
+}
+
+function readInjections(): InjectionRecord[] {
+  try {
+    return JSON.parse(readFileSync(INJECTIONS_FILE, 'utf-8'))
+  } catch {
+    return []
+  }
+}

--- a/src/features/session-state.ts
+++ b/src/features/session-state.ts
@@ -328,25 +328,30 @@ export function extractHandoffDescription(handoff: HandoffFile): string {
  * cross-project handoffs are always visible.
  * Returns them sorted by timestamp, most recent first.
  */
-export function readRecentHandoffs(_cwd?: string | null): HandoffFile[] {
+export function readRecentHandoffs(cwd?: string | null): HandoffFile[] {
   const results: HandoffFile[] = []
   const cutoff = Date.now() - MAX_HANDOFF_AGE_MS
 
-  // Scan all project subdirectories under SESSIONS_DIR
+  // If cwd is provided, only scan that project's directory
   const dirsToScan: string[] = []
-  try {
-    const entries = readdirSync(SESSIONS_DIR, { withFileTypes: true })
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        dirsToScan.push(resolve(SESSIONS_DIR, entry.name))
+  if (cwd) {
+    const projectDir = resolve(SESSIONS_DIR, encodeCwd(cwd))
+    dirsToScan.push(projectDir)
+  } else {
+    // Scan all project subdirectories under SESSIONS_DIR
+    try {
+      const entries = readdirSync(SESSIONS_DIR, { withFileTypes: true })
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          dirsToScan.push(resolve(SESSIONS_DIR, entry.name))
+        }
       }
+    } catch {
+      // Sessions dir doesn't exist yet
     }
-  } catch {
-    // Sessions dir doesn't exist yet
+    // Also scan the root sessions dir (for files saved without cwd)
+    dirsToScan.push(SESSIONS_DIR)
   }
-
-  // Also scan the root sessions dir (for files saved without cwd)
-  dirsToScan.push(SESSIONS_DIR)
 
   for (const dir of dirsToScan) {
     try {
@@ -612,6 +617,8 @@ interface ParsedHandoff {
   decisions: string[]
   userPreferences: string[]
   blockers: string[]
+  whatSurprisedMe: string[]
+  gotchas: string[]
   remainder: string | null
 }
 
@@ -624,6 +631,8 @@ const SECTION_HEADERS: Record<string, keyof ParsedHandoff> = {
   'DECISIONS:': 'decisions',
   'USER_PREFERENCES:': 'userPreferences',
   'BLOCKERS:': 'blockers',
+  'WHAT_SURPRISED_ME:': 'whatSurprisedMe',
+  'GOTCHAS:': 'gotchas',
 }
 
 /**
@@ -642,6 +651,8 @@ export function parseStructuredHandoff(text: string): ParsedHandoff {
     decisions: [],
     userPreferences: [],
     blockers: [],
+    whatSurprisedMe: [],
+    gotchas: [],
     remainder: null,
   }
 

--- a/src/features/skill-suggest.ts
+++ b/src/features/skill-suggest.ts
@@ -1,4 +1,5 @@
 import type { SessionState, TurnMetrics, ToolCallSummary } from '../types.js'
+import type { SubagentSignal } from './subagent-intel.js'
 
 export interface WorkflowPattern {
   /** Normalized sequence of tool calls */
@@ -224,6 +225,57 @@ function deduplicatePatterns(patterns: WorkflowPattern[]): WorkflowPattern[] {
   }
 
   return result
+}
+
+/**
+ * Generate skill suggestions from subagent patterns.
+ *
+ * Subagent descriptions are the richest signal for recurring workflows.
+ * "Fix post-merge build errors" appearing 3+ times across sessions
+ * is a strong candidate for a skill.
+ */
+export function generateSubagentSkillSuggestions(
+  signals: SubagentSignal[],
+  minOccurrences = 3
+): SkillSuggestion[] {
+  // Import here to avoid circular deps at module level
+  const { detectPatterns } = require('./subagent-intel.js') as typeof import('./subagent-intel.js')
+
+  const patterns = detectPatterns(signals)
+  const suggestions: SkillSuggestion[] = []
+
+  for (const pattern of patterns) {
+    if (pattern.count < minOccurrences) continue
+
+    const name = pattern.pattern
+      .replace(/\b(batch|group)\s*n\b/gi, '')
+      .replace(/[^a-z0-9\s]/gi, '')
+      .trim()
+      .split(/\s+/)
+      .slice(0, 3)
+      .join('-')
+      .toLowerCase() || 'workflow'
+
+    const prompt =
+      `[clauditor — skill suggestion from agent patterns]: Claude spawned agents for "${pattern.descriptions[0]}" ` +
+      `${pattern.count} times across sessions.\n\n` +
+      `Ask the user: "I noticed you frequently need '${pattern.descriptions[0]}'. ` +
+      `Want me to create a /${name} skill so this runs automatically?"\n\n` +
+      `If the user agrees, create .claude/skills/${name}/SKILL.md.`
+
+    suggestions.push({
+      name,
+      pattern: {
+        steps: [{ tool: 'Agent', input: pattern.descriptions[0] }],
+        sessionCount: pattern.count,
+        seenIn: pattern.descriptions.slice(0, 5),
+        fingerprint: `subagent:${pattern.pattern}`,
+      },
+      prompt,
+    })
+  }
+
+  return suggestions.slice(0, 3)
 }
 
 /**

--- a/src/features/subagent-intel.test.ts
+++ b/src/features/subagent-intel.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import {
+  classifySubagent,
+  scanSubagents,
+  scanSessionSubagents,
+  detectPatterns,
+  type SubagentSignal,
+} from './subagent-intel.js'
+
+// ─── classifySubagent ──────────────────────────────────────
+
+describe('classifySubagent', () => {
+  it('classifies fix-related descriptions', () => {
+    expect(classifySubagent('Fix post-merge build errors')).toBe('fix')
+    expect(classifySubagent('Resolve merge conflicts')).toBe('fix')
+    expect(classifySubagent('Resolve test file merge conflicts')).toBe('fix')
+    expect(classifySubagent('Fix remaining 9 Copilot comments')).toBe('fix')
+    expect(classifySubagent('Fix tests missing VariableAgentRunner')).toBe('fix')
+  })
+
+  it('classifies query/search descriptions', () => {
+    expect(classifySubagent('Query App Insights for undefined file types')).toBe('query')
+    expect(classifySubagent('Search codebase for file assertion types')).toBe('query')
+    expect(classifySubagent('Search DB scripts for file type schema')).toBe('query')
+  })
+
+  it('classifies research/investigation descriptions', () => {
+    expect(classifySubagent('Research industry page stability benchmarks')).toBe('research')
+    expect(classifySubagent('Investigate Redis timeout issue')).toBe('research')
+    expect(classifySubagent('Explore Thunders browser automation')).toBe('research')
+    expect(classifySubagent('How multi-app variables work')).toBe('research')
+  })
+
+  it('classifies find/trace descriptions', () => {
+    expect(classifySubagent('Find Selector.Invalid logic')).toBe('find')
+    expect(classifySubagent('Trace StepsToActions pipeline flow')).toBe('find')
+    expect(classifySubagent('Find existing DeterministicSelector tests')).toBe('find')
+  })
+
+  it('classifies check/verify descriptions', () => {
+    expect(classifySubagent('Check DeterministicSelector validation bug')).toBe('check')
+    expect(classifySubagent('Verify and resolve Copilot comments')).toBe('fix') // "resolve" wins over "verify"
+    expect(classifySubagent('Verify 4 stabilization fixes')).toBe('check')
+  })
+
+  it('classifies create/build descriptions', () => {
+    expect(classifySubagent('Create Notion DB batch 1')).toBe('create')
+    expect(classifySubagent('Draft issue response')).toBe('create')
+    expect(classifySubagent('Generate test steps')).toBe('create')
+  })
+
+  it('returns other for unclassifiable descriptions', () => {
+    expect(classifySubagent('Backfill email on 100 Notion pages')).toBe('other')
+    expect(classifySubagent('Download screenshots from blob storage')).toBe('other')
+  })
+})
+
+// ─── detectPatterns ────────────────────────────────────────
+
+describe('detectPatterns', () => {
+  it('groups similar descriptions', () => {
+    const signals: SubagentSignal[] = [
+      makeSignal('Create Notion DB batch 1'),
+      makeSignal('Create Notion DB batch 2'),
+      makeSignal('Create Notion DB batch 3'),
+      makeSignal('Fix build errors'),
+      makeSignal('Something unique'),
+    ]
+
+    const patterns = detectPatterns(signals)
+    expect(patterns.length).toBe(1)
+    expect(patterns[0].pattern).toContain('create notion db batch')
+    expect(patterns[0].count).toBe(3)
+    expect(patterns[0].category).toBe('create')
+  })
+
+  it('returns empty for all unique descriptions', () => {
+    const signals: SubagentSignal[] = [
+      makeSignal('Fix build errors'),
+      makeSignal('Query App Insights'),
+      makeSignal('Research benchmarks'),
+    ]
+
+    const patterns = detectPatterns(signals)
+    expect(patterns.length).toBe(0)
+  })
+
+  it('normalizes ticket numbers and hashes', () => {
+    const signals: SubagentSignal[] = [
+      makeSignal('Fix PR #123 comments'),
+      makeSignal('Fix PR #456 comments'),
+    ]
+
+    const patterns = detectPatterns(signals)
+    expect(patterns.length).toBe(1)
+    expect(patterns[0].count).toBe(2)
+  })
+})
+
+// ─── scanSubagents (with mock filesystem) ──────────────────
+
+const TEST_CWD = '/tmp/test-subagent-intel-project'
+const ENCODED = TEST_CWD.replace(/[^a-zA-Z0-9]/g, '-')
+const PROJECT_DIR = resolve(homedir(), '.claude', 'projects', ENCODED)
+
+describe('scanSubagents', () => {
+  beforeEach(() => {
+    const sessionDir = resolve(PROJECT_DIR, '00000000-0000-0000-0000-000000000001', 'subagents')
+    mkdirSync(sessionDir, { recursive: true })
+
+    writeFileSync(
+      resolve(sessionDir, 'agent-a1.meta.json'),
+      JSON.stringify({ agentType: 'general-purpose', description: 'Fix build errors' })
+    )
+    writeFileSync(
+      resolve(sessionDir, 'agent-a2.meta.json'),
+      JSON.stringify({ agentType: 'Explore', description: 'Find retry logic' })
+    )
+
+    // Add a second session
+    const sessionDir2 = resolve(PROJECT_DIR, '00000000-0000-0000-0000-000000000002', 'subagents')
+    mkdirSync(sessionDir2, { recursive: true })
+
+    writeFileSync(
+      resolve(sessionDir2, 'agent-a3.meta.json'),
+      JSON.stringify({ agentType: 'general-purpose', description: 'Fix test failures' })
+    )
+  })
+
+  afterEach(() => {
+    try { rmSync(PROJECT_DIR, { recursive: true }) } catch {}
+  })
+
+  it('scans all sessions and returns signals', () => {
+    const summary = scanSubagents(TEST_CWD)
+    expect(summary.total).toBe(3)
+    expect(summary.byCategory.fix).toBe(2)
+    expect(summary.byCategory.find).toBe(1)
+    expect(summary.byAgentType['general-purpose']).toBe(2)
+    expect(summary.byAgentType['Explore']).toBe(1)
+  })
+
+  it('returns empty for non-existent project', () => {
+    const summary = scanSubagents('/tmp/no-such-project-ever-xyz')
+    expect(summary.total).toBe(0)
+  })
+})
+
+describe('scanSessionSubagents', () => {
+  beforeEach(() => {
+    const sessionDir = resolve(PROJECT_DIR, '00000000-0000-0000-0000-000000000001', 'subagents')
+    mkdirSync(sessionDir, { recursive: true })
+
+    writeFileSync(
+      resolve(sessionDir, 'agent-a1.meta.json'),
+      JSON.stringify({ agentType: 'general-purpose', description: 'Fix build errors' })
+    )
+  })
+
+  afterEach(() => {
+    try { rmSync(PROJECT_DIR, { recursive: true }) } catch {}
+  })
+
+  it('scans only the specified session', () => {
+    const signals = scanSessionSubagents(TEST_CWD, '00000000-0000-0000-0000-000000000001')
+    expect(signals.length).toBe(1)
+    expect(signals[0].description).toBe('Fix build errors')
+  })
+
+  it('returns empty for non-existent session', () => {
+    const signals = scanSessionSubagents(TEST_CWD, '99999999-9999-9999-9999-999999999999')
+    expect(signals.length).toBe(0)
+  })
+})
+
+// ─── Helpers ──────────────────────────────────────────────
+
+function makeSignal(description: string): SubagentSignal {
+  return {
+    sessionId: 'test-session',
+    agentId: 'agent-test',
+    agentType: 'general-purpose',
+    description,
+    category: classifySubagent(description),
+    filesTouched: [],
+    turnCount: 5,
+    timestamp: Date.now(),
+  }
+}

--- a/src/features/subagent-intel.ts
+++ b/src/features/subagent-intel.ts
@@ -1,0 +1,334 @@
+/**
+ * Subagent Intelligence — extract signals from Claude Code's subagent metadata.
+ *
+ * Claude Code stores subagent data at:
+ *   ~/.claude/projects/<project>/<session-id>/subagents/
+ *     agent-<id>.meta.json  — { agentType, description }
+ *     agent-<id>.jsonl      — full subagent transcript
+ *
+ * This module reads meta files (zero LLM cost) and extracts:
+ * - Task descriptions and categories
+ * - Recurring patterns across sessions
+ * - Files touched by subagents
+ */
+
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs'
+import { resolve, basename } from 'node:path'
+import { homedir } from 'node:os'
+
+export type SubagentCategory = 'fix' | 'query' | 'research' | 'find' | 'check' | 'create' | 'other'
+
+export interface SubagentSignal {
+  sessionId: string
+  agentId: string
+  agentType: string
+  description: string
+  category: SubagentCategory
+  filesTouched: string[]
+  turnCount: number
+  timestamp: number // mtime of meta file
+}
+
+export interface SubagentSummary {
+  total: number
+  byCategory: Record<SubagentCategory, number>
+  byAgentType: Record<string, number>
+  signals: SubagentSignal[]
+}
+
+/**
+ * Scan all subagents for a project directory.
+ * Reads only .meta.json files (fast, zero LLM cost).
+ */
+export function scanSubagents(cwd: string): SubagentSummary {
+  const projectDir = findProjectDir(cwd)
+  if (!projectDir) return emptySummary()
+
+  const signals: SubagentSignal[] = []
+
+  try {
+    const entries = readdirSync(projectDir, { withFileTypes: true })
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+
+      // Session directories are UUIDs
+      if (!isUUID(entry.name)) continue
+
+      const subagentsDir = resolve(projectDir, entry.name, 'subagents')
+      if (!existsSync(subagentsDir)) continue
+
+      const sessionId = entry.name
+
+      try {
+        const files = readdirSync(subagentsDir)
+        const metaFiles = files.filter(f => f.endsWith('.meta.json'))
+
+        for (const metaFile of metaFiles) {
+          try {
+            const metaPath = resolve(subagentsDir, metaFile)
+            const meta = JSON.parse(readFileSync(metaPath, 'utf-8'))
+            const mtime = statSync(metaPath).mtimeMs
+
+            if (!meta.description) continue
+
+            // Extract agent ID from filename: agent-<id>.meta.json
+            const agentId = basename(metaFile, '.meta.json')
+
+            // Lightweight file extraction from transcript
+            const jsonlFile = metaFile.replace('.meta.json', '.jsonl')
+            const jsonlPath = resolve(subagentsDir, jsonlFile)
+            const { files: filesTouched, turnCount } = extractTranscriptMeta(jsonlPath)
+
+            signals.push({
+              sessionId,
+              agentId,
+              agentType: meta.agentType || 'unknown',
+              description: meta.description,
+              category: classifySubagent(meta.description),
+              filesTouched,
+              turnCount,
+              timestamp: mtime,
+            })
+          } catch {
+            // Skip unreadable meta files
+          }
+        }
+      } catch {
+        // Skip unreadable session dirs
+      }
+    }
+  } catch {
+    return emptySummary()
+  }
+
+  return buildSummary(signals)
+}
+
+/**
+ * Scan subagents for a single session only.
+ * Used by the stop hook to push signals for the current session.
+ */
+export function scanSessionSubagents(cwd: string, sessionId: string): SubagentSignal[] {
+  const projectDir = findProjectDir(cwd)
+  if (!projectDir) return []
+
+  const subagentsDir = resolve(projectDir, sessionId, 'subagents')
+  if (!existsSync(subagentsDir)) return []
+
+  const signals: SubagentSignal[] = []
+
+  try {
+    const files = readdirSync(subagentsDir)
+    const metaFiles = files.filter(f => f.endsWith('.meta.json'))
+
+    for (const metaFile of metaFiles) {
+      try {
+        const metaPath = resolve(subagentsDir, metaFile)
+        const meta = JSON.parse(readFileSync(metaPath, 'utf-8'))
+        const mtime = statSync(metaPath).mtimeMs
+
+        if (!meta.description) continue
+
+        const agentId = basename(metaFile, '.meta.json')
+        const jsonlFile = metaFile.replace('.meta.json', '.jsonl')
+        const jsonlPath = resolve(subagentsDir, jsonlFile)
+        const { files: filesTouched, turnCount } = extractTranscriptMeta(jsonlPath)
+
+        signals.push({
+          sessionId,
+          agentId,
+          agentType: meta.agentType || 'unknown',
+          description: meta.description,
+          category: classifySubagent(meta.description),
+          filesTouched,
+          turnCount,
+          timestamp: mtime,
+        })
+      } catch {
+        // Skip
+      }
+    }
+  } catch {
+    // Skip
+  }
+
+  return signals
+}
+
+/**
+ * Classify a subagent description into a category.
+ * Uses keyword matching — no LLM needed.
+ */
+export function classifySubagent(description: string): SubagentCategory {
+  const lower = description.toLowerCase()
+
+  // Order matters — more specific patterns first
+  if (/\b(fix|resolve|repair|patch|correct)\b/.test(lower)) return 'fix'
+  if (/\b(create|build|implement|write|generate|draft)\b/.test(lower)) return 'create'
+  if (/\b(query|search|grep|find.*in|look.*for)\b/.test(lower)) return 'query'
+  if (/\b(check|verify|validate|test|confirm)\b/.test(lower)) return 'check'
+  if (/\b(research|investigate|explore|understand|how|why)\b/.test(lower)) return 'research'
+  if (/\b(find|trace|locate|discover)\b/.test(lower)) return 'find'
+
+  return 'other'
+}
+
+/**
+ * Detect recurring patterns across subagent descriptions.
+ * Groups similar descriptions and returns those appearing 2+ times.
+ */
+export function detectPatterns(signals: SubagentSignal[]): Array<{
+  pattern: string
+  count: number
+  category: SubagentCategory
+  descriptions: string[]
+}> {
+  // Normalize descriptions for grouping
+  const groups = new Map<string, { descriptions: string[]; category: SubagentCategory }>()
+
+  for (const signal of signals) {
+    const key = normalizeDescription(signal.description)
+    const existing = groups.get(key)
+    if (existing) {
+      existing.descriptions.push(signal.description)
+    } else {
+      groups.set(key, {
+        descriptions: [signal.description],
+        category: signal.category,
+      })
+    }
+  }
+
+  return Array.from(groups.entries())
+    .filter(([, v]) => v.descriptions.length >= 2)
+    .map(([pattern, v]) => ({
+      pattern,
+      count: v.descriptions.length,
+      category: v.category,
+      descriptions: v.descriptions,
+    }))
+    .sort((a, b) => b.count - a.count)
+}
+
+// ─── Helpers ────────────────────────────────────────────────
+
+function findProjectDir(cwd: string): string | null {
+  const claudeProjectsDir = resolve(homedir(), '.claude', 'projects')
+  if (!existsSync(claudeProjectsDir)) return null
+
+  try {
+    const dirs = readdirSync(claudeProjectsDir, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+
+    const encoded = cwd.replace(/[^a-zA-Z0-9]/g, '-')
+
+    for (const dir of dirs) {
+      if (dir.name.includes(encoded.slice(0, 30)) || encoded.includes(dir.name.slice(0, 30))) {
+        return resolve(claudeProjectsDir, dir.name)
+      }
+    }
+  } catch {}
+
+  return null
+}
+
+function isUUID(s: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s)
+}
+
+/**
+ * Extract lightweight metadata from a subagent transcript.
+ * Only reads file paths from tool_use calls — does NOT parse full content.
+ */
+function extractTranscriptMeta(jsonlPath: string): { files: string[]; turnCount: number } {
+  if (!existsSync(jsonlPath)) return { files: [], turnCount: 0 }
+
+  try {
+    const content = readFileSync(jsonlPath, 'utf-8')
+    const lines = content.split('\n').filter(l => l.trim())
+    const files = new Set<string>()
+    let turnCount = 0
+
+    for (const line of lines) {
+      try {
+        const record = JSON.parse(line)
+        if (record.type === 'assistant') turnCount++
+
+        // Extract file paths from tool_use inputs
+        if (record.type === 'assistant' && Array.isArray(record.message?.content)) {
+          for (const block of record.message.content) {
+            if (block.type === 'tool_use') {
+              const input = block.input
+              if (input?.file_path) files.add(normalizeFilePath(input.file_path))
+              if (input?.path) files.add(normalizeFilePath(input.path))
+              if (input?.command) {
+                // Extract file paths from common shell commands
+                const pathMatches = input.command.match(/(?:^|\s)((?:\/|\.\/)\S+\.\w+)/g)
+                if (pathMatches) {
+                  for (const m of pathMatches) {
+                    files.add(normalizeFilePath(m.trim()))
+                  }
+                }
+              }
+            }
+          }
+        }
+      } catch {
+        // Skip unparseable lines
+      }
+    }
+
+    // Filter out non-source paths (tool-results caches, temp files, etc.)
+    const filtered = Array.from(files).filter(f =>
+      !f.includes('tool-results') &&
+      !f.includes('subagents/') &&
+      !f.includes('.jsonl') &&
+      !f.startsWith('/tmp/')
+    )
+    return { files: filtered.slice(0, 20), turnCount }
+  } catch {
+    return { files: [], turnCount: 0 }
+  }
+}
+
+function normalizeFilePath(path: string): string {
+  // Strip absolute path prefixes to get relative paths
+  return path.replace(/^\/Users\/[^/]+\/[^/]+\/[^/]+\/[^/]+\//, '')
+}
+
+/**
+ * Normalize a description for pattern grouping.
+ * Strips specific identifiers to group similar tasks.
+ */
+function normalizeDescription(desc: string): string {
+  return desc
+    .toLowerCase()
+    .replace(/\b(batch|group)\s*\d+\b/g, 'batch N')        // "batch 1" → "batch N"
+    .replace(/\b(pr|issue|ticket)\s*#?\d+\b/g, '$1 N')      // "PR #123" → "PR N"
+    .replace(/\b[a-f0-9]{7,40}\b/g, 'HASH')                 // git hashes
+    .replace(/\b\d{4,}\b/g, 'N')                              // large numbers (ticket IDs)
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function emptySummary(): SubagentSummary {
+  return {
+    total: 0,
+    byCategory: { fix: 0, query: 0, research: 0, find: 0, check: 0, create: 0, other: 0 },
+    byAgentType: {},
+    signals: [],
+  }
+}
+
+function buildSummary(signals: SubagentSignal[]): SubagentSummary {
+  const byCategory: Record<SubagentCategory, number> = { fix: 0, query: 0, research: 0, find: 0, check: 0, create: 0, other: 0 }
+  const byAgentType: Record<string, number> = {}
+
+  for (const s of signals) {
+    byCategory[s.category]++
+    byAgentType[s.agentType] = (byAgentType[s.agentType] || 0) + 1
+  }
+
+  return { total: signals.length, byCategory, byAgentType, signals }
+}

--- a/src/hooks/post-compact.ts
+++ b/src/hooks/post-compact.ts
@@ -1,5 +1,5 @@
 import { logActivity } from '../features/activity-log.js'
-import { savePostCompactSummary } from '../features/session-state.js'
+import { savePostCompactSummary, parseStructuredHandoff } from '../features/session-state.js'
 import { readStdin, outputDecision } from './shared.js'
 
 /**
@@ -11,6 +11,7 @@ import { readStdin, outputDecision } from './shared.js'
  * because the LLM knows the reasoning, blockers, and plan.
  *
  * Saves per-session to ~/.clauditor/sessions/<encoded-cwd>/<timestamp>.md
+ * Also pushes structured learnings to the hub (if any found in the summary).
  */
 export async function handlePostCompactHook(): Promise<void> {
   const input = await readStdin()
@@ -48,7 +49,92 @@ export async function handlePostCompactHook(): Promise<void> {
     // Non-critical
   }
 
+  // Push to hub: structured learnings + summary as team memory
+  await pushCompactToHub(summary, hookInput.cwd || null)
+
   outputDecision({})
+}
+
+/**
+ * Push compact summary to hub:
+ * 1. Structured learnings (FAILED_APPROACHES, etc.) → knowledge entries
+ * 2. Full summary → team memory (searchable via RAG)
+ */
+async function pushCompactToHub(summary: string, cwd: string | null): Promise<void> {
+    try {
+      const { resolveHubContext } = await import('../hub/client.js')
+      const { scrubSecrets } = await import('../features/secret-scrubber.js')
+      const { queueAndSend } = await import('../hub/push-queue.js')
+      const { createHash } = await import('node:crypto')
+      const hub = resolveHubContext(cwd || undefined)
+      if (!hub) return
+
+      // 1. Push structured learnings if present
+      const parsed = parseStructuredHandoff(summary)
+      if (parsed.isStructured) {
+        const learnings: Array<{ type: string; content: string }> = []
+        for (const item of parsed.failedApproaches) {
+          learnings.push({ type: 'failed_approach', content: scrubSecrets(item).scrubbed })
+        }
+        for (const item of parsed.dependencies) {
+          learnings.push({ type: 'dependency', content: scrubSecrets(item).scrubbed })
+        }
+        for (const item of parsed.decisions) {
+          learnings.push({ type: 'decision', content: scrubSecrets(item).scrubbed })
+        }
+        for (const item of parsed.whatSurprisedMe) {
+          learnings.push({ type: 'surprise', content: scrubSecrets(item).scrubbed })
+        }
+        for (const item of parsed.gotchas) {
+          learnings.push({ type: 'gotcha', content: scrubSecrets(item).scrubbed })
+        }
+
+        if (learnings.length > 0) {
+          await queueAndSend(
+            `${hub.config.url}/api/v1/handoff/learn`,
+            { 'X-Clauditor-Key': hub.config.apiKey, 'Content-Type': 'application/json' },
+            {
+              project_hash: hub.projectHash,
+              developer_hash: hub.config.developerHash,
+              project_name: hub.remoteUrl,
+              learnings,
+            }
+          )
+        }
+      }
+
+      // 2. Push full summary as a team memory (searchable via RAG)
+      const scrubbed = scrubSecrets(summary).scrubbed
+      const contentHash = createHash('sha256').update(scrubbed).digest('hex').slice(0, 16)
+      const timestamp = new Date().toISOString().slice(0, 16).replace('T', ' ')
+      await queueAndSend(
+        `${hub.config.url}/api/v1/memory/sync`,
+        { 'X-Clauditor-Key': hub.config.apiKey, 'Content-Type': 'application/json' },
+        {
+          project_hash: hub.projectHash,
+          developer_hash: hub.config.developerHash,
+          project_name: hub.remoteUrl,
+          memories: [{
+            name: `Session summary (${timestamp})`,
+            description: 'Claude\'s own session summary captured at compaction',
+            memory_type: 'session_summary',
+            content: scrubbed,
+            content_hash: contentHash,
+            source_file: `compact_${contentHash}`,
+            scope: 'team',
+          }],
+        }
+      )
+
+      const { logActivity } = await import('../features/activity-log.js')
+      logActivity({
+        type: 'notification',
+        session: 'compact',
+        message: `Pushed session summary to hub (${scrubbed.length} chars)`,
+      }).catch(() => {})
+    } catch (err) {
+      process.stderr.write(`clauditor: compact hub push failed: ${err instanceof Error ? err.message : err}\n`)
+    }
 }
 
 // Run if invoked directly

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -29,8 +29,14 @@ import { readStdin, outputDecision, writeJsonFileAtomic, readJsonFile } from './
  * (inside Claude Code) instead of requiring a separate dashboard.
  */
 export async function handlePostToolUseHook(): Promise<void> {
-  const input = await readStdin()
-  const hookInput = JSON.parse(input) as PostToolUseHookInput
+  let hookInput: PostToolUseHookInput
+  try {
+    const input = await readStdin()
+    hookInput = JSON.parse(input) as PostToolUseHookInput
+  } catch {
+    outputDecision({})
+    return
+  }
 
   const decision = await processToolResult(hookInput)
 
@@ -69,7 +75,9 @@ async function processToolResult(input: PostToolUseHookInput): Promise<HookDecis
           content: scrubFragmentContent(f.content).content,
         }))
         await pushKnowledge(hub.projectHash, hub.config.developerHash, scrubbed, hub.config, hub.remoteUrl)
-      } catch {}
+      } catch (err) {
+        process.stderr.write(`clauditor: hub push failed: ${err instanceof Error ? err.message : err}\n`)
+      }
     })())
   }
 
@@ -118,17 +126,35 @@ async function processToolResult(input: PostToolUseHookInput): Promise<HookDecis
       try {
         const fixResult = recordFix(cwd, input.tool_input.command)
         if (fixResult) {
-          // Push the fix to the hub so team members learn from it
-          hubPush(cwd, [{
-            type: 'error',
-            content: {
-              command: fixResult.command,
-              error_message: fixResult.error,
-              fix: fixResult.fix,
-            },
-          }])
+          // Push the fix as a durable knowledge entry (not a fragment)
+          hubPushes.push((async () => {
+            try {
+              const { resolveHubContext } = await import('../hub/client.js')
+              const { scrubSecrets } = await import('../features/secret-scrubber.js')
+              const hub = resolveHubContext(cwd)
+              if (!hub) return
+              const { queueAndSend } = await import('../hub/push-queue.js')
+              await queueAndSend(
+                `${hub.config.url}/api/v1/handoff/learn`,
+                { 'X-Clauditor-Key': hub.config.apiKey, 'Content-Type': 'application/json' },
+                {
+                  project_hash: hub.projectHash,
+                  developer_hash: hub.config.developerHash,
+                  project_name: hub.remoteUrl,
+                  learnings: [{
+                    type: 'error_fix',
+                    content: scrubSecrets(`${fixResult.command} failed with: ${fixResult.error}\nFix: ${fixResult.fix}`).scrubbed,
+                  }],
+                }
+              )
+            } catch (err) {
+              process.stderr.write(`clauditor: error-fix hub push failed: ${err instanceof Error ? err.message : err}\n`)
+            }
+          })())
         }
-      } catch {}
+      } catch (err) {
+        process.stderr.write(`clauditor: error capture failed: ${err instanceof Error ? err.message : err}\n`)
+      }
     }
 
     // Push errors to hub (local recording already handled above)
@@ -162,8 +188,11 @@ async function processToolResult(input: PostToolUseHookInput): Promise<HookDecis
                   method: 'POST',
                   headers: { 'X-Clauditor-Key': hub.config.apiKey, 'Content-Type': 'application/json' },
                   body: JSON.stringify({ entry_ids: pending.hubEntryIds, outcome }),
+                  signal: AbortSignal.timeout(10000),
                 })
-              } catch {}
+              } catch (err) {
+                process.stderr.write(`clauditor: outcome push failed: ${err instanceof Error ? err.message : err}\n`)
+              }
             })())
           }
 
@@ -239,7 +268,25 @@ async function processToolResult(input: PostToolUseHookInput): Promise<HookDecis
             )
           }
         }
-      } catch {}
+      } catch (err) {
+        process.stderr.write(`clauditor: hub file knowledge query failed: ${err instanceof Error ? err.message : err}\n`)
+      }
+    }
+  }
+
+  // 2c. Gotcha injection for Read/View — fire-and-forget, rate-limited per file per session
+  if (input.tool_name === 'Read' || input.tool_name === 'View') {
+    const filePath = (input.tool_input?.file_path as string) || ''
+    if (filePath && cwd && !hasCheckedGotcha(input.session_id, filePath)) {
+      markGotchaChecked(input.session_id, filePath)
+      // Fire-and-forget: push the gotcha query into hubPushes so we await it
+      // before process exit, but don't block the main hook path.
+      hubPushes.push((async () => {
+        const gotchaCtx = await queryGotchasForFile(cwd, filePath)
+        if (gotchaCtx) {
+          parts.push(gotchaCtx)
+        }
+      })())
     }
   }
 
@@ -598,12 +645,20 @@ function checkSessionRotationBlock(sessionId: string, turns: TurnMetrics[]): Hoo
 
   if (wasteFactor < cal.wasteThreshold) return null
 
-  // Re-block at every 2x increase: if we blocked at 5x, block again at 7x, 9x, etc.
-  // Tracks the waste level when last blocked, not just true/false.
+  // Re-block logic: track the waste level when last blocked.
+  // If waste dropped significantly (compaction happened), reset and block again.
+  // Otherwise, only re-block at every 2x increase to avoid spamming.
   const blockedAt = readJsonFile<Record<string, number>>(BLOCK_NUDGE_FILE, {})
   const key = `post-${sessionId}`
   const lastBlockedWaste = blockedAt[key] || 0
-  if (lastBlockedWaste > 0 && wasteFactor < lastBlockedWaste + 2) return null
+  if (lastBlockedWaste > 0) {
+    // Waste dropped by more than half → compaction happened, reset and re-block
+    if (wasteFactor < lastBlockedWaste / 2) {
+      // Reset — will proceed to block below
+    } else if (wasteFactor < lastBlockedWaste + 2) {
+      return null
+    }
+  }
 
   // Mark as blocked at this waste level
   blockedAt[key] = wasteFactor
@@ -640,6 +695,8 @@ function checkSessionRotationBlock(sessionId: string, turns: TurnMetrics[]): Hoo
       `DECISIONS:\n- (choices made and why, e.g. "chose X over Y because Z")\n\n` +
       `USER_PREFERENCES:\n- (anything the user explicitly asked for or rejected)\n\n` +
       `BLOCKERS:\n- (unresolved issues, things that need user input)\n\n` +
+      `WHAT_SURPRISED_ME:\n- (unexpected behavior, undocumented quirks)\n\n` +
+      `GOTCHAS:\n- (file: path/to/file — specific warning about this file)\n\n` +
       `3. In the new session, tell the user to just say "continue where I left off" — clauditor will inject the saved context automatically.\n` +
       `4. Include the marker [clauditor-rotation] at the end of your response so clauditor can capture your summary.`,
   }
@@ -647,7 +704,55 @@ function checkSessionRotationBlock(sessionId: string, turns: TurnMetrics[]): Hoo
 
 const BLOCK_NUDGE_FILE = resolve(homedir(), '.clauditor', 'prompt-block-nudge.json')
 
+// ─── Gotcha Check ──────────────────────────────────────────────
+// Rate limit: max 1 gotcha check per file per session.
+// Persisted to disk because each hook invocation is a separate process.
+const GOTCHA_CHECKED_FILE = resolve(homedir(), '.clauditor', 'gotcha-checked.json')
 
+function hasCheckedGotcha(sessionId: string, filePath: string): boolean {
+  const data = readJsonFile<Record<string, string[]>>(GOTCHA_CHECKED_FILE, {})
+  return (data[sessionId] || []).includes(filePath)
+}
+
+function markGotchaChecked(sessionId: string, filePath: string): void {
+  const data = readJsonFile<Record<string, string[]>>(GOTCHA_CHECKED_FILE, {})
+  if (!data[sessionId]) data[sessionId] = []
+  if (!data[sessionId].includes(filePath)) {
+    data[sessionId].push(filePath)
+  }
+  try { writeJsonFileAtomic(GOTCHA_CHECKED_FILE, data) } catch {}
+}
+
+/**
+ * Fire-and-forget gotcha query for a file.
+ * Queries GET /api/v1/gotchas?project_hash=X&filepath=Y
+ * Returns additionalContext string if gotchas found, null otherwise.
+ */
+async function queryGotchasForFile(cwd: string, filePath: string): Promise<string | null> {
+  try {
+    const { resolveHubContext } = await import('../hub/client.js')
+    const hub = resolveHubContext(cwd)
+    if (!hub) return null
+
+    const url = `${hub.config.url}/api/v1/gotchas?project_hash=${encodeURIComponent(hub.projectHash)}&filepath=${encodeURIComponent(filePath)}`
+    const res = await fetch(url, {
+      headers: { 'X-Clauditor-Key': hub.config.apiKey, 'Content-Type': 'application/json' },
+    })
+    if (!res.ok) return null
+
+    const data = (await res.json()) as { gotchas?: Array<{ title: string; description: string; solution?: string }> }
+    if (!data.gotchas || data.gotchas.length === 0) return null
+
+    const lines = data.gotchas.map((g) =>
+      `- **${g.title}**: ${g.description}${g.solution ? ` → ${g.solution}` : ''}`
+    )
+    return (
+      `[clauditor hub — gotchas for \`${filePath.split('/').pop()}\`]:\n` + lines.join('\n')
+    )
+  } catch {
+    return null
+  }
+}
 
 const ERROR_PATTERNS = [
   /error:/i,

--- a/src/hooks/pre-tool-use.ts
+++ b/src/hooks/pre-tool-use.ts
@@ -69,8 +69,14 @@ export function clearOutcomePending(): void {
  * as additional context. Non-blocking — Claude decides whether to use it.
  */
 export async function handlePreToolUseHook(): Promise<void> {
-  const input = await readStdin()
-  const hookInput = JSON.parse(input) as PreToolUseHookInput
+  let hookInput: PreToolUseHookInput
+  try {
+    const input = await readStdin()
+    hookInput = JSON.parse(input) as PreToolUseHookInput
+  } catch {
+    outputDecision({})
+    return
+  }
 
   const decision = await processPreToolUse(hookInput)
   outputDecision(decision)

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -32,12 +32,13 @@ export async function handleSessionStartHook(): Promise<void> {
   // Prune stale state files — lightweight, runs once per session start
   try { pruneStaleStateFiles() } catch {}
 
-  const context = await buildSessionStartContext(hookInput.cwd)
+  const context = await buildSessionStartContext(hookInput.cwd, hookInput.session_id)
   outputDecision(context)
 }
 
 async function buildSessionStartContext(
-  cwd?: string
+  cwd?: string,
+  sessionId?: string,
 ): Promise<HookDecision> {
   const parts: string[] = []
 
@@ -120,23 +121,54 @@ async function buildSessionStartContext(
         const { resolveHubContext, pullCoreTier } = await import('../hub/client.js')
         const hub = resolveHubContext(cwd)
         if (hub) {
+          // Flush any queued pushes from previous sessions (retry failed sends)
+          try {
+            const { flushQueue } = await import('../hub/push-queue.js')
+            flushQueue().catch(() => {})
+          } catch {}
+
           // Sync local auto-memory to hub (fire-and-forget)
           try {
             const { readAutoMemory, syncMemoryToHub } = await import('../hub/memory-sync.js')
             const memories = readAutoMemory(cwd)
             if (memories.length > 0) {
-              syncMemoryToHub(memories, hub.projectHash, hub.config.developerHash, hub.config).catch(() => {})
+              syncMemoryToHub(memories, hub.projectHash, hub.config.developerHash, hub.config, hub.remoteUrl).catch(() => {})
             }
           } catch {}
 
-          // Pull team knowledge
-          const core = await pullCoreTier(hub.projectHash, hub.config)
-          if (core?.core) {
-            parts.push(
-              `[clauditor hub — team knowledge]:\n` +
-              core.core
+          // Pull knowledge brief — top 5 things to know about this project
+          try {
+            const briefController = new AbortController()
+            const briefTimeout = setTimeout(() => briefController.abort(), 5000)
+            const briefRes = await fetch(
+              `${hub.config.url}/api/v1/knowledge/brief?project_hash=${hub.projectHash}&max=5`,
+              { headers: { 'X-Clauditor-Key': hub.config.apiKey }, signal: briefController.signal }
             )
-          }
+            clearTimeout(briefTimeout)
+            if (briefRes.ok) {
+              const briefData = await briefRes.json() as {
+                brief: Array<{ id: string | null; title: string; content: string; score: number; reason: string }>
+              }
+              if (briefData.brief?.length > 0) {
+                const lines = briefData.brief.map((item, i) =>
+                  `${i + 1}. ${item.title}\n   ${item.content.slice(0, 150).replace(/\n/g, ' ')}`
+                )
+                parts.push(
+                  `[clauditor — what your team learned about this project]:\n` +
+                  lines.join('\n\n')
+                )
+
+                // Record injected entry IDs for outcome tracking
+                const entryIds = briefData.brief.map(b => b.id).filter((id): id is string => id !== null)
+                if (entryIds.length > 0) {
+                  try {
+                    const { recordInjection } = await import('../features/outcome-tracker.js')
+                    recordInjection(sessionId || 'unknown', entryIds)
+                  } catch {}
+                }
+              }
+            }
+          } catch {}
         }
       } catch {
         // Hub unavailable — local knowledge is enough
@@ -148,7 +180,7 @@ async function buildSessionStartContext(
     // Check for repeating workflows that could become skills
     const { SessionStore } = await import('../daemon/store.js')
     const { SessionWatcher } = await import('../daemon/watcher.js')
-    const { detectWorkflowPatterns, generateSkillSuggestions } = await import('../features/skill-suggest.js')
+    const { detectWorkflowPatterns, generateSkillSuggestions, generateSubagentSkillSuggestions } = await import('../features/skill-suggest.js')
 
     const store = new SessionStore()
     const watcher = new SessionWatcher(store, { projectsDir })
@@ -157,6 +189,18 @@ async function buildSessionStartContext(
     const sessions = store.getAll()
     const patterns = detectWorkflowPatterns(sessions)
     const suggestions = generateSkillSuggestions(patterns)
+
+    // Also check subagent patterns for skill candidates
+    if (cwd) {
+      try {
+        const { scanSubagents } = await import('../features/subagent-intel.js')
+        const subagentSummary = scanSubagents(cwd)
+        if (subagentSummary.total > 0) {
+          const subagentSuggestions = generateSubagentSkillSuggestions(subagentSummary.signals)
+          suggestions.push(...subagentSuggestions)
+        }
+      } catch {}
+    }
 
     if (suggestions.length > 0) {
       // Only inject the top suggestion to avoid noise

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -16,8 +16,14 @@ import { readStdin, outputDecision } from './shared.js'
  * the session to prevent token waste.
  */
 export async function handleStopHook(): Promise<void> {
-  const input = await readStdin()
-  const hookInput = JSON.parse(input) as StopHookInput
+  let hookInput: StopHookInput
+  try {
+    const input = await readStdin()
+    hookInput = JSON.parse(input) as StopHookInput
+  } catch {
+    outputDecision({})
+    return
+  }
 
   // If stop_hook_active is true, another stop hook is already running.
   // Do not block again to prevent infinite loops.
@@ -26,9 +32,12 @@ export async function handleStopHook(): Promise<void> {
     return
   }
 
-  // Check if Claude just wrote a rotation handoff summary
-  // (after PostToolUse blocked with exit code 2, Claude writes a summary)
-  captureRotationHandoff(hookInput)
+  // Await all async hub pushes before outputDecision — process exits after stdout write
+  await Promise.allSettled([
+    captureRotationHandoff(hookInput),
+    pushSubagentSignals(hookInput),
+    reportKnowledgeOutcomes(hookInput),
+  ])
 
   const decision = analyzeForLoop(hookInput)
   outputDecision(decision)
@@ -111,7 +120,7 @@ export function analyzeForLoop(input: StopHookInput): HookDecision {
  * rotation handoff, save it as a rich per-session file — replacing the
  * sparse mechanical extraction that was saved during the block.
  */
-function captureRotationHandoff(input: StopHookInput): void {
+async function captureRotationHandoff(input: StopHookInput): Promise<void> {
   const msg = input.last_assistant_message
   if (!msg || msg.length < 100) return
 
@@ -126,25 +135,10 @@ function captureRotationHandoff(input: StopHookInput): void {
 
   if (!isRotationHandoff) return
 
-  // Extract cwd from transcript
-  let cwd: string | null = null
-  try {
-    const content = readFileSync(input.transcript_path, 'utf-8')
-    const lines = content.split('\n')
-    for (let i = lines.length - 1; i >= 0; i--) {
-      try {
-        const r = JSON.parse(lines[i])
-        if (r.type === 'user' && r.cwd) {
-          cwd = r.cwd
-          break
-        }
-      } catch {}
-    }
-  } catch {}
+  const cwd = extractCwd(input.transcript_path)
 
   try {
-    // Don't await — stop hook should not block on async scoring
-    savePostCompactSummary(msg, cwd, input.transcript_path || null).catch(() => {})
+    await savePostCompactSummary(msg, cwd, input.transcript_path || null)
 
     logActivity({
       type: 'context_warning',
@@ -155,51 +149,134 @@ function captureRotationHandoff(input: StopHookInput): void {
     process.stderr.write(`clauditor: failed to save rotation handoff: ${err}\n`)
   }
 
-  // Push structured learnings to hub (fire-and-forget, scrubbed)
-  ;(async () => {
-    try {
-      const { resolveHubContext } = await import('../hub/client.js')
-      const { scrubSecrets } = await import('../features/secret-scrubber.js')
-      const { parseStructuredHandoff } = await import('../features/session-state.js')
-      const hub = resolveHubContext(cwd || undefined)
-      if (!hub) return
+  // Push structured learnings to hub (awaited so it completes before process exits)
+  try {
+    const { resolveHubContext } = await import('../hub/client.js')
+    const { scrubSecrets } = await import('../features/secret-scrubber.js')
+    const { parseStructuredHandoff } = await import('../features/session-state.js')
+    const hub = resolveHubContext(cwd || undefined)
+    if (!hub) return
 
-      // Parse structured sections from the handoff
-      const parsed = parseStructuredHandoff(msg)
+    const parsed = parseStructuredHandoff(msg)
 
-      if (parsed.isStructured) {
-        // Convert structured sections to learnings for durable storage
-        const learnings: Array<{ type: string; content: string; tags?: string[] }> = []
+    if (parsed.isStructured) {
+      const learnings: Array<{ type: string; content: string; tags?: string[] }> = []
 
-        for (const item of parsed.failedApproaches) {
-          learnings.push({ type: 'failed_approach', content: scrubSecrets(item).scrubbed })
-        }
-        for (const item of parsed.dependencies) {
-          learnings.push({ type: 'dependency', content: scrubSecrets(item).scrubbed })
-        }
-        for (const item of parsed.decisions) {
-          learnings.push({ type: 'decision', content: scrubSecrets(item).scrubbed })
-        }
-
-        if (learnings.length > 0) {
-          try {
-            await fetch(`${hub.config.url}/api/v1/handoff/learn`, {
-              method: 'POST',
-              headers: {
-                'X-Clauditor-Key': hub.config.apiKey,
-                'Content-Type': 'application/json',
-              },
-              body: JSON.stringify({
-                project_hash: hub.projectHash,
-                developer_hash: hub.config.developerHash,
-                learnings,
-              }),
-            })
-          } catch {}
-        }
+      for (const item of parsed.failedApproaches) {
+        learnings.push({ type: 'failed_approach', content: scrubSecrets(item).scrubbed })
       }
-    } catch {}
-  })()
+      for (const item of parsed.dependencies) {
+        learnings.push({ type: 'dependency', content: scrubSecrets(item).scrubbed })
+      }
+      for (const item of parsed.decisions) {
+        learnings.push({ type: 'decision', content: scrubSecrets(item).scrubbed })
+      }
+      for (const item of parsed.whatSurprisedMe) {
+        learnings.push({ type: 'surprise', content: scrubSecrets(item).scrubbed })
+      }
+      for (const item of parsed.gotchas) {
+        learnings.push({ type: 'gotcha', content: scrubSecrets(item).scrubbed })
+      }
+
+      if (learnings.length > 0) {
+        const { queueAndSend } = await import('../hub/push-queue.js')
+        await queueAndSend(
+          `${hub.config.url}/api/v1/handoff/learn`,
+          { 'X-Clauditor-Key': hub.config.apiKey, 'Content-Type': 'application/json' },
+          {
+            project_hash: hub.projectHash,
+            developer_hash: hub.config.developerHash,
+            project_name: hub.remoteUrl,
+            learnings,
+          }
+        )
+      }
+    }
+  } catch {}
+}
+
+/**
+ * Report knowledge outcomes — did the injected brief help?
+ *
+ * Simple heuristic: if the session didn't hit a loop (healthy),
+ * all injected entries get a positive signal.
+ */
+async function reportKnowledgeOutcomes(input: StopHookInput): Promise<void> {
+  if (input.stop_hook_active) return
+
+  const cwd = extractCwd(input.transcript_path)
+  if (!cwd) return
+
+  try {
+    const { reportOutcomes } = await import('../features/outcome-tracker.js')
+    const reported = await reportOutcomes(input.session_id, cwd, true)
+    if (reported > 0) {
+      logActivity({
+        type: 'notification',
+        session: input.session_id.slice(0, 8),
+        message: `Reported ${reported} positive outcomes for injected knowledge`,
+      }).catch(() => {})
+    }
+  } catch (err) {
+    process.stderr.write(`clauditor: outcome report failed: ${err instanceof Error ? err.message : err}\n`)
+  }
+}
+
+/**
+ * Push subagent metadata from the current session to the hub.
+ * Reads .meta.json files for the session's subagents and sends
+ * descriptions + categories. Fire-and-forget.
+ */
+async function pushSubagentSignals(input: StopHookInput): Promise<void> {
+  const cwd = extractCwd(input.transcript_path)
+  if (!cwd) return
+
+  try {
+    const { resolveHubContext } = await import('../hub/client.js')
+    const hub = resolveHubContext(cwd)
+    if (!hub) return
+
+    const { scanSessionSubagents } = await import('../features/subagent-intel.js')
+    const signals = scanSessionSubagents(cwd, input.session_id)
+    if (signals.length === 0) return
+
+    const { queueAndSend } = await import('../hub/push-queue.js')
+    await queueAndSend(
+      `${hub.config.url}/api/v1/subagents/sync`,
+      { 'X-Clauditor-Key': hub.config.apiKey, 'Content-Type': 'application/json' },
+      {
+        project_hash: hub.projectHash,
+        developer_hash: hub.config.developerHash,
+        project_name: hub.remoteUrl,
+        signals: signals.map(s => ({
+          session_id: s.sessionId,
+          agent_id: s.agentId,
+          agent_type: s.agentType,
+          description: s.description,
+          category: s.category,
+          files_touched: s.filesTouched,
+          turn_count: s.turnCount,
+        })),
+      }
+    )
+  } catch (err) {
+    process.stderr.write(`clauditor: subagent push failed: ${err instanceof Error ? err.message : err}\n`)
+  }
+}
+
+/** Extract cwd from the last user record in the transcript. */
+function extractCwd(transcriptPath: string): string | null {
+  try {
+    const content = readFileSync(transcriptPath, 'utf-8')
+    const lines = content.split('\n')
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        const r = JSON.parse(lines[i])
+        if (r.type === 'user' && r.cwd) return r.cwd
+      } catch {}
+    }
+  } catch {}
+  return null
 }
 
 function hashValue(value: unknown): string {

--- a/src/hub/auth-server.ts
+++ b/src/hub/auth-server.ts
@@ -65,41 +65,110 @@ export function waitForAuth(state: string): Promise<{ result: AuthResult; port: 
         return
       }
 
-      // Send success page to the browser
-      res.writeHead(200, { 'Content-Type': 'text/html' })
+      // Send branded success page
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
       res.end(`
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-  <title>clauditor — logged in</title>
+  <meta charset="utf-8">
+  <title>clauditor — Connected</title>
   <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
-      font-family: system-ui, -apple-system, sans-serif;
+      font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
       display: flex;
       align-items: center;
       justify-content: center;
       min-height: 100vh;
-      margin: 0;
-      background: #0d0d14;
-      color: #e8e8f0;
+      background: #09090f;
+      color: #ededf0;
     }
-    .card {
+    .container {
       text-align: center;
-      padding: 3rem;
-      background: #181828;
-      border-radius: 1rem;
-      border: 1px solid #2a2a42;
+      max-width: 420px;
+      padding: 0 1.5rem;
     }
-    .check { font-size: 3rem; margin-bottom: 1rem; }
-    h1 { font-size: 1.25rem; margin: 0 0 0.5rem; }
-    p { color: #9898b0; font-size: 0.875rem; margin: 0; }
+    .logo {
+      font-size: 1.5rem;
+      font-weight: 800;
+      letter-spacing: -0.02em;
+      margin-bottom: 2rem;
+    }
+    .logo span { color: #f09040; }
+    .card {
+      padding: 2.5rem;
+      background: #111118;
+      border-radius: 1rem;
+      border: 1px solid #1a1a2a;
+    }
+    .icon {
+      width: 56px;
+      height: 56px;
+      border-radius: 16px;
+      background: rgba(240, 144, 64, 0.1);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 1.5rem;
+      font-size: 1.5rem;
+    }
+    h1 {
+      font-size: 1.25rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+    }
+    .team {
+      color: #f09040;
+      font-weight: 600;
+    }
+    .subtitle {
+      color: #a0a0b8;
+      font-size: 0.875rem;
+      line-height: 1.5;
+      margin-bottom: 1.5rem;
+    }
+    .steps {
+      text-align: left;
+      background: #07070b;
+      border-radius: 0.75rem;
+      padding: 1rem 1.25rem;
+      font-size: 0.8rem;
+      color: #a0a0b8;
+      line-height: 1.7;
+    }
+    .steps .done {
+      color: #4ade80;
+    }
+    .steps .next {
+      color: #ededf0;
+      font-weight: 500;
+    }
+    .footer {
+      margin-top: 1.5rem;
+      font-size: 0.75rem;
+      color: #6b6b85;
+    }
   </style>
 </head>
 <body>
-  <div class="card">
-    <div class="check">✓</div>
-    <h1>Logged in to ${teamName}</h1>
-    <p>You can close this tab and return to your terminal.</p>
+  <div class="container">
+    <div class="logo"><span>clauditor</span></div>
+    <div class="card">
+      <div class="icon">&#x2713;</div>
+      <h1>Connected to <span class="team">${teamName}</span></h1>
+      <p class="subtitle">
+        Your AI coding sessions will now share knowledge across your team.
+        Return to your terminal to continue.
+      </p>
+      <div class="steps">
+        <div class="done">&#x2713; Authenticated</div>
+        <div class="done">&#x2713; Team connected</div>
+        <div class="done">&#x2713; Knowledge sync enabled</div>
+        <div class="next">&#x2192; Start a Claude Code session to begin</div>
+      </div>
+    </div>
+    <p class="footer">You can close this tab.</p>
   </div>
 </body>
 </html>
@@ -180,13 +249,20 @@ export async function startAuthServer(state: string): Promise<{
 
       if (!apiKey || !teamName || !teamId) { res.writeHead(400); res.end(); return }
 
-      res.writeHead(200, { 'Content-Type': 'text/html' })
-      res.end(`<!DOCTYPE html><html><head><meta charset="utf-8"><title>clauditor</title>
-<style>body{font-family:system-ui;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#0d0d14;color:#e8e8f0}
-.c{text-align:center;padding:3rem;background:#181828;border-radius:1rem;border:1px solid #2a2a42}
-.k{font-size:3rem;margin-bottom:1rem}h1{font-size:1.25rem;margin:0 0 .5rem}p{color:#9898b0;font-size:.875rem;margin:0}</style>
-</head><body><div class="c"><div class="k">✓</div><h1>Logged in to ${teamName}</h1><p>You can close this tab.</p></div>
-<script>setTimeout(function(){window.close()},2000)</script></body></html>`)
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+      res.end(`<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>clauditor — Connected</title>
+<style>*{margin:0;padding:0;box-sizing:border-box}body{font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;background:#09090f;color:#ededf0}
+.ctr{text-align:center;max-width:420px;padding:0 1.5rem}.logo{font-size:1.5rem;font-weight:800;letter-spacing:-0.02em;margin-bottom:2rem}.logo span{color:#f09040}
+.card{padding:2.5rem;background:#111118;border-radius:1rem;border:1px solid #1a1a2a}.icon{width:56px;height:56px;border-radius:16px;background:rgba(240,144,64,0.1);display:flex;align-items:center;justify-content:center;margin:0 auto 1.5rem;font-size:1.5rem;color:#f09040}
+h1{font-size:1.25rem;font-weight:700;margin-bottom:0.5rem}.team{color:#f09040;font-weight:600}.sub{color:#a0a0b8;font-size:0.875rem;line-height:1.5;margin-bottom:1.5rem}
+.steps{text-align:left;background:#07070b;border-radius:0.75rem;padding:1rem 1.25rem;font-size:0.8rem;color:#a0a0b8;line-height:1.7}.done{color:#4ade80}.next{color:#ededf0;font-weight:500}
+.ft{margin-top:1.5rem;font-size:0.75rem;color:#6b6b85}</style>
+</head><body><div class="ctr"><div class="logo"><span>clauditor</span></div><div class="card">
+<div class="icon">&#x2713;</div>
+<h1>Connected to <span class="team">${teamName}</span></h1>
+<p class="sub">Your AI coding sessions will now share knowledge across your team. Return to your terminal to continue.</p>
+<div class="steps"><div class="done">&#x2713; Authenticated</div><div class="done">&#x2713; Team connected</div><div class="done">&#x2713; Knowledge sync enabled</div><div class="next">&#x2192; Start a Claude Code session to begin</div></div>
+</div><p class="ft">You can close this tab.</p></div></body></html>`)
 
       clearTimeout(timeout)
       setTimeout(() => {

--- a/src/hub/client.ts
+++ b/src/hub/client.ts
@@ -33,6 +33,7 @@ async function hubFetch(
   const url = `${hubConfig.url}${path}`
   const res = await fetch(url, {
     ...options,
+    signal: options.signal || AbortSignal.timeout(15000),
     headers: {
       'X-Clauditor-Key': hubConfig.apiKey,
       'Content-Type': 'application/json',

--- a/src/hub/memory-sync.ts
+++ b/src/hub/memory-sync.ts
@@ -88,7 +88,8 @@ export async function syncMemoryToHub(
   entries: MemoryEntry[],
   projectHash: string,
   developerHash: string,
-  hubConfig: { apiKey: string; url: string }
+  hubConfig: { apiKey: string; url: string },
+  projectName?: string
 ): Promise<{ synced: number; skipped: number }> {
   if (entries.length === 0) return { synced: 0, skipped: 0 }
 
@@ -103,7 +104,9 @@ export async function syncMemoryToHub(
         project_hash: projectHash,
         developer_hash: developerHash,
         memories: entries,
+        project_name: projectName || null,
       }),
+      signal: AbortSignal.timeout(15000),
     })
 
     if (!res.ok) return { synced: 0, skipped: entries.length }
@@ -116,30 +119,30 @@ export async function syncMemoryToHub(
 // ─── Helpers ────────────────────────────────────────────────
 
 function findMemoryDir(cwd: string, claudeProjectsDir: string): string | null {
-  // Claude Code encodes the project path as the directory name
-  // Try to find a matching directory
+  // Claude Code encodes the project path: replace non-alphanumeric with '-'
+  // Try exact match first, then fallback to fuzzy
   try {
+    const encoded = cwd.replace(/[^a-zA-Z0-9]/g, '-')
+
+    // Exact match (preferred)
+    const exactPath = resolve(claudeProjectsDir, encoded, 'memory')
+    if (existsSync(exactPath)) return exactPath
+
+    // Collapsed hyphens variant
+    const collapsed = encoded.replace(/-+/g, '-').slice(0, 100)
+    const collapsedPath = resolve(claudeProjectsDir, collapsed, 'memory')
+    if (existsSync(collapsedPath)) return collapsedPath
+
+    // Fuzzy match — but require full encoded name match, not just prefix
     const dirs = readdirSync(claudeProjectsDir, { withFileTypes: true })
       .filter((d) => d.isDirectory())
 
     for (const dir of dirs) {
-      // The directory name is an encoded version of the project path
-      // Check if this directory contains a memory/ subfolder
       const memPath = resolve(claudeProjectsDir, dir.name, 'memory')
-      if (existsSync(memPath)) {
-        // Check if this directory matches our cwd by decoding
-        // Claude Code uses: cwd.replace(/[^a-zA-Z0-9]/g, '-')
-        const encoded = cwd.replace(/[^a-zA-Z0-9]/g, '-')
-        if (dir.name.includes(encoded.slice(0, 30)) || encoded.includes(dir.name.slice(0, 30))) {
-          return memPath
-        }
+      if (existsSync(memPath) && dir.name === encoded) {
+        return memPath
       }
     }
-
-    // Fallback: try direct encoding
-    const encoded = cwd.replace(/[^a-zA-Z0-9]/g, '-').replace(/-+/g, '-').slice(0, 100)
-    const directPath = resolve(claudeProjectsDir, encoded, 'memory')
-    if (existsSync(directPath)) return directPath
   } catch {}
 
   return null

--- a/src/hub/push-queue.ts
+++ b/src/hub/push-queue.ts
@@ -1,0 +1,125 @@
+/**
+ * Push Queue — ensures data is never lost if the hub is unreachable.
+ *
+ * Instead of fire-and-forget HTTP calls, data is:
+ *   1. Written to a local queue file (disk-persisted)
+ *   2. Sent to the hub
+ *   3. Removed from queue on success
+ *   4. Retried next session on failure
+ *
+ * This guarantees zero data loss even if the hub is down for days.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+
+const QUEUE_DIR = resolve(homedir(), '.clauditor')
+const QUEUE_FILE = resolve(QUEUE_DIR, 'push-queue.json')
+
+interface QueueItem {
+  id: string
+  url: string
+  method: string
+  headers: Record<string, string>
+  body: string
+  createdAt: number
+  attempts: number
+}
+
+/**
+ * Add an item to the queue and attempt to send it.
+ * If send fails, item stays in queue for retry.
+ */
+export async function queueAndSend(
+  url: string,
+  headers: Record<string, string>,
+  body: Record<string, unknown>
+): Promise<boolean> {
+  const item: QueueItem = {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    url,
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+    createdAt: Date.now(),
+    attempts: 0,
+  }
+
+  // Persist to queue first (data safety)
+  const queue = readQueue()
+  queue.push(item)
+  writeQueue(queue)
+
+  // Try to send
+  const success = await trySend(item)
+
+  if (success) {
+    // Remove from queue
+    const updated = readQueue().filter(q => q.id !== item.id)
+    writeQueue(updated)
+  }
+
+  return success
+}
+
+/**
+ * Flush the queue — retry all pending items.
+ * Called at session start to catch up on failed pushes.
+ */
+export async function flushQueue(): Promise<{ sent: number; pending: number }> {
+  const queue = readQueue()
+  if (queue.length === 0) return { sent: 0, pending: 0 }
+
+  let sent = 0
+  const remaining: QueueItem[] = []
+
+  for (const item of queue) {
+    // Skip items older than 7 days
+    if (Date.now() - item.createdAt > 7 * 24 * 60 * 60 * 1000) continue
+
+    // Max 5 retry attempts
+    if (item.attempts >= 5) continue
+
+    item.attempts++
+    const success = await trySend(item)
+
+    if (success) {
+      sent++
+    } else {
+      remaining.push(item)
+    }
+  }
+
+  writeQueue(remaining)
+  return { sent, pending: remaining.length }
+}
+
+async function trySend(item: QueueItem): Promise<boolean> {
+  try {
+    const res = await fetch(item.url, {
+      method: item.method,
+      headers: item.headers,
+      body: item.body,
+      signal: AbortSignal.timeout(10000),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+function readQueue(): QueueItem[] {
+  try {
+    return JSON.parse(readFileSync(QUEUE_FILE, 'utf-8'))
+  } catch {
+    return []
+  }
+}
+
+function writeQueue(queue: QueueItem[]): void {
+  try {
+    mkdirSync(QUEUE_DIR, { recursive: true })
+    writeFileSync(QUEUE_FILE, JSON.stringify(queue))
+  } catch {}
+}


### PR DESCRIPTION
## Summary

- **Auto-memory sync**: reads ~/.claude/projects/<project>/memory/, scrubs secrets, deduplicates by SHA256, syncs to hub. Exact directory matching prevents cross-project contamination.
- **Subagent intelligence**: scans .meta.json files, classifies by category (fix/query/research/find/check), detects recurring patterns for skill suggestions.
- **Outcome tracking + push queue**: tracks which knowledge entries were injected, reports outcomes. Disk-persisted queue with 7-day expiry ensures zero data loss when hub is unreachable.
- **Hook reliability**: all async hub pushes awaited via Promise.allSettled before process exit. PostCompact pushes session summaries as team memories. Rotation re-block resets after compaction.
- **clauditor sync command**: pushes auto-memory + session handoff summaries + flushes pending queue. Tracks synced hashes to avoid duplicates.
- **clauditor login**: browser auth with branded success page, auto-install hooks, auto-configure MCP server (HTTP transport).
- **Hub client**: 15s default timeout on all fetch calls.

## Test plan

- [ ] clauditor login from a git repo — hooks installed, MCP configured, memories synced
- [ ] clauditor sync — pushes auto-memory and session summaries, idempotent on re-run
- [ ] Session rotation triggers handoff push to hub
- [ ] PostCompact pushes session summary as team memory
- [ ] Kill session mid-push — push queue retries on next session start