### PR TITLE
feat: multi-provider support for 10 AI coding tools

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -158,23 +158,109 @@ program
 
 program
   .command('install')
-  .description('Register clauditor hooks in ~/.claude/settings.json')
+  .description('Register clauditor hooks for your AI coding tools')
+  .option('--provider <name>', 'Install for a specific provider (claude, codex, cursor, windsurf, cline)')
   .option('--claude-dir <path>', 'Path to Claude config directory (default: ~/.claude)')
-  .action(async (opts: { claudeDir?: string }) => {
-    const { installHooks } = await import('./install.js')
-    const messages = await installHooks(opts.claudeDir)
-    for (const msg of messages) {
-      console.log(msg)
+  .action(async (opts: { provider?: string; claudeDir?: string }) => {
+    const { registry } = await import('./providers/index.js')
+
+    // Explicit single provider
+    if (opts.provider) {
+      const provider = registry.get(opts.provider)
+      if (!provider.hooks) {
+        console.log(`${provider.displayName} (Tier ${provider.tier}) does not support hooks.`)
+        console.log('Only session monitoring features are available for this provider.')
+        return
+      }
+      if (opts.provider === 'claude') {
+        // Use the full Claude installer (includes skills, calibration)
+        const { installHooks } = await import('./install.js')
+        const messages = await installHooks(opts.claudeDir)
+        for (const msg of messages) console.log(msg)
+      } else {
+        console.log(`Installing clauditor hooks for ${provider.displayName}...`)
+        const messages = await provider.hooks.install()
+        for (const msg of messages) console.log(msg)
+      }
+      return
     }
+
+    // Default: auto-detect all installed tools
+    const detected = registry.detect()
+    if (detected.length === 0) {
+      console.log('No AI coding tools detected on this machine.')
+      console.log('Supported tools: ' + registry.names().join(', '))
+      return
+    }
+
+    console.log('Detecting AI coding tools...\n')
+    const all = registry.getAll()
+    for (const p of all) {
+      const found = detected.some(d => d.name === p.name)
+      console.log(`  ${found ? '✓' : '✗'} ${p.displayName.padEnd(20)} ${found ? p.directories.configDir().replace(homedir(), '~') : '(not found)'}`)
+    }
+
+    const hookable = detected.filter(p => p.hooks)
+    const monitoring = detected.filter(p => !p.hooks)
+
+    if (hookable.length > 0) {
+      console.log('\nInstalling hooks...\n')
+      for (const provider of hookable) {
+        if (provider.name === 'claude') {
+          // Use the full Claude installer (includes skills, calibration)
+          const { installHooks } = await import('./install.js')
+          const messages = await installHooks(opts.claudeDir)
+          console.log(`  ${provider.displayName}:`)
+          for (const msg of messages) console.log(`    ${msg}`)
+        } else {
+          const messages = await provider.hooks!.install()
+          console.log(`  ${provider.displayName}:`)
+          for (const msg of messages) console.log(`    ${msg}`)
+        }
+      }
+    }
+
+    if (monitoring.length > 0) {
+      console.log(`\n  ${monitoring.map(p => p.displayName).join(', ')}: session monitoring only (no hooks)`)
+    }
+
+    console.log(`\n${hookable.length} provider(s) with hooks installed. Run \`clauditor providers\` to see status.`)
   })
 
 // ─── clauditor uninstall ──────────────────────────────────────────
 
 program
   .command('uninstall')
-  .description('Remove clauditor hooks from ~/.claude/settings.json')
+  .description('Remove clauditor hooks from an AI coding tool')
+  .option('--provider <name>', 'Provider to uninstall hooks from (claude, codex, cursor, windsurf, cline)')
+  .option('--all', 'Uninstall hooks from all providers')
   .option('--claude-dir <path>', 'Path to Claude config directory (default: ~/.claude)')
-  .action(async (opts: { claudeDir?: string }) => {
+  .action(async (opts: { provider?: string; all?: boolean; claudeDir?: string }) => {
+    const { registry } = await import('./providers/index.js')
+
+    if (opts.all) {
+      const detected = registry.detect()
+      for (const provider of detected) {
+        if (!provider.hooks) continue
+        console.log(`\n── ${provider.displayName} ──`)
+        const messages = await provider.hooks.uninstall()
+        for (const msg of messages) console.log(`  ${msg}`)
+      }
+      return
+    }
+
+    if (opts.provider && opts.provider !== 'claude') {
+      const provider = registry.get(opts.provider)
+      if (!provider.hooks) {
+        console.log(`${provider.displayName} does not have hooks to uninstall.`)
+        return
+      }
+      const messages = await provider.hooks.uninstall()
+      for (const msg of messages) console.log(msg)
+      return
+    }
+
+    // Default: Claude Code
     const { uninstallHooks } = await import('./install.js')
     const messages = await uninstallHooks(opts.claudeDir)
     for (const msg of messages) {
@@ -188,7 +274,7 @@ const DEFAULT_HUB_URL = 'https://www.clauditor.ai'
 
 program
   .command('login')
-  .description('Sign in to clauditor hub')
+  .description('Sign in to clauditor hub and set up all detected AI coding tools')
   .option('--hub-url <url>', 'Hub URL', DEFAULT_HUB_URL)
   .option('--device', 'Use device code flow instead of opening browser')
   .action(async (options) => {
@@ -213,26 +299,33 @@ program
     const isSSH = !!(process.env.SSH_CONNECTION || process.env.SSH_TTY || process.env.SSH_CLIENT)
     const useDeviceFlow = options.device || isSSH
 
-    // Auto-install hooks if not already installed
+    // Auto-detect and install hooks for all detected providers
     try {
-      const { existsSync } = await import('node:fs')
-      const { resolve } = await import('node:path')
-      const { homedir } = await import('node:os')
-      const settingsPath = resolve(homedir(), '.claude', 'settings.json')
-      if (existsSync(settingsPath)) {
-        const settings = JSON.parse((await import('node:fs')).readFileSync(settingsPath, 'utf-8'))
-        const hasHooks = settings.hooks && Object.keys(settings.hooks).length > 0
-        if (!hasHooks) {
-          console.log('\n  Setting up clauditor hooks...')
-          const { installHooks } = await import('./install.js')
-          const msgs = await installHooks()
-          msgs.forEach((m: string) => console.log(m))
+      const { registry } = await import('./providers/index.js')
+      const detected = registry.detect()
+      const hookable = detected.filter(p => p.hooks)
+
+      if (hookable.length > 0) {
+        console.log('\n  Detecting AI coding tools...')
+        for (const p of detected) {
+          const hasHooks = p.hooks ? 'hooks' : 'monitoring'
+          console.log(`    ✓ ${p.displayName} (${hasHooks})`)
         }
+
+        console.log('\n  Installing hooks...')
+        for (const provider of hookable) {
+          if (provider.name === 'claude') {
+            const { installHooks } = await import('./install.js')
+            await installHooks()
+            console.log(`    ✓ ${provider.displayName}: hooks installed`)
+          } else {
+            await provider.hooks!.install()
+            console.log(`    ✓ ${provider.displayName}: hooks installed`)
+          }
+        }
+        console.log(`\n  ${hookable.length} provider(s) configured.`)
       } else {
-        console.log('\n  Setting up clauditor hooks...')
-        const { installHooks } = await import('./install.js')
-        const msgs = await installHooks()
-        msgs.forEach((m: string) => console.log(m))
+        console.log('\n  No AI coding tools detected — hooks can be installed later with `clauditor install`')
       }
     } catch {
       // Non-critical — hooks can be installed manually with `clauditor install`
@@ -1421,15 +1514,40 @@ program
     console.log('')
   })
 
+// ─── clauditor providers ─────────────────────────────────────────
+
+program
+  .command('providers')
+  .description('List all supported AI coding tools and their status')
+  .action(async () => {
+    const { registry } = await import('./providers/index.js')
+    const all = registry.getAll()
+    const detected = registry.detect()
+    const detectedNames = new Set(detected.map(p => p.name))
+
+    console.log('Supported AI coding tools:\n')
+    console.log('  Provider            Tier  Hooks  Status')
+    console.log('  ─────────────────── ────  ─────  ──────')
+    for (const p of all) {
+      const status = detectedNames.has(p.name) ? '✓ detected' : '  not found'
+      const hooks = p.hooks ? 'yes' : 'no'
+      const name = p.displayName.padEnd(20)
+      console.log(`  ${name}${p.tier}     ${hooks.padEnd(6)} ${status}`)
+    }
+    console.log(`\nInstall hooks:  clauditor install --provider <name>`)
+    console.log(`Install all:    clauditor install --all`)
+  })
+
 // ─── clauditor hook <name> ───────────────────────────────────────
 
 const hookCmd = program
   .command('hook')
-  .description('Internal hook handlers (called by Claude Code)')
+  .description('Internal hook handlers (called by AI coding tools)')
 
 hookCmd
   .command('stop')
   .description('Stop hook handler')
+  .option('--provider <name>', 'Provider name (default: claude)')
   .action(async () => {
     await import('./hooks/stop.js')
   })
@@ -1437,6 +1555,7 @@ hookCmd
 hookCmd
   .command('post-tool-use')
   .description('PostToolUse hook handler')
+  .option('--provider <name>', 'Provider name (default: claude)')
   .action(async () => {
     await import('./hooks/post-tool-use.js')
   })
@@ -1444,6 +1563,7 @@ hookCmd
 hookCmd
   .command('pre-tool-use')
   .description('PreToolUse hook handler')
+  .option('--provider <name>', 'Provider name (default: claude)')
   .action(async () => {
     await import('./hooks/pre-tool-use.js')
   })
@@ -1451,6 +1571,7 @@ hookCmd
 hookCmd
   .command('user-prompt-submit')
   .description('UserPromptSubmit hook handler — blocks oversized sessions')
+  .option('--provider <name>', 'Provider name (default: claude)')
   .action(async () => {
     await import('./hooks/user-prompt-submit.js')
   })
@@ -1458,6 +1579,7 @@ hookCmd
 hookCmd
   .command('pre-compact')
   .description('PreCompact hook handler — saves context before compaction')
+  .option('--provider <name>', 'Provider name (default: claude)')
   .action(async () => {
     await import('./hooks/pre-compact.js')
   })
@@ -1465,6 +1587,7 @@ hookCmd
 hookCmd
   .command('post-compact')
   .description('PostCompact hook handler — captures Claude\'s own session summary')
+  .option('--provider <name>', 'Provider name (default: claude)')
   .action(async () => {
     await import('./hooks/post-compact.js')
   })
@@ -1472,6 +1595,7 @@ hookCmd
 hookCmd
   .command('session-start')
   .description('SessionStart hook handler')
+  .option('--provider <name>', 'Provider name (default: claude)')
   .action(async () => {
     await import('./hooks/session-start.js')
   })

--- a/src/features/calibration.ts
+++ b/src/features/calibration.ts
@@ -69,8 +69,8 @@ export function loadCalibration(): CalibrationData {
  * Every number comes from the user's own data. Nothing hardcoded
  * except the rotation cost estimate (5 turns of warmup).
  */
-export function calibrate(): CalibrationData {
-  const projectsDir = resolve(homedir(), '.claude/projects')
+export function calibrate(sessionsDir?: string): CalibrationData {
+  const projectsDir = sessionsDir ?? resolve(homedir(), '.claude/projects')
   const profiles: SessionProfile[] = []
 
   try {

--- a/src/features/cost-tracker.ts
+++ b/src/features/cost-tracker.ts
@@ -1,5 +1,6 @@
 import type { TokenUsage, PricingConfig, TurnMetrics } from '../types.js'
 import { MODEL_PRICING } from '../types.js'
+import type { PricingResolver } from '../providers/types.js'
 
 export interface CostEstimate {
   inputCost: number
@@ -49,15 +50,18 @@ export function estimateCost(
 
 /**
  * Detect model from assistant record and return appropriate pricing.
+ * Accepts an optional PricingResolver for multi-provider support.
  */
-export function getPricingForModel(modelId: string): PricingConfig {
-  // Match model IDs like "claude-sonnet-4-6-20260301" to base pricing
+export function getPricingForModel(modelId: string, pricingResolver?: PricingResolver): PricingConfig {
+  if (pricingResolver) {
+    return pricingResolver.getPricing(modelId)
+  }
+  // Fallback: check Claude pricing (backward compat)
   for (const [key, pricing] of Object.entries(MODEL_PRICING)) {
     if (modelId.startsWith(key)) {
       return pricing
     }
   }
-  // Default to Sonnet pricing
   return MODEL_PRICING['claude-sonnet-4-6']
 }
 

--- a/src/features/quota-report.ts
+++ b/src/features/quota-report.ts
@@ -39,8 +39,8 @@ export interface QuotaBrief {
  * Analyze all sessions across all projects for the last N days.
  * Deduplicates continued sessions by message ID.
  */
-export function computeQuotaBrief(days: number = 7): QuotaBrief {
-  const projectsDir = resolve(homedir(), '.claude/projects')
+export function computeQuotaBrief(days: number = 7, sessionsDir?: string): QuotaBrief {
+  const projectsDir = sessionsDir ?? resolve(homedir(), '.claude/projects')
   const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
   const sessions: SessionReport[] = []
   const seenMessageIds = new Set<string>()
@@ -148,8 +148,8 @@ export interface TimeAnalysis {
  * Analyze token costs by hour of day across all sessions.
  * This can reveal peak-hour pricing multipliers.
  */
-export function computeTimeAnalysis(days: number = 7): TimeAnalysis {
-  const projectsDir = resolve(homedir(), '.claude/projects')
+export function computeTimeAnalysis(days: number = 7, sessionsDir?: string): TimeAnalysis {
+  const projectsDir = sessionsDir ?? resolve(homedir(), '.claude/projects')
   const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
   const seenMessageIds = new Set<string>()
 

--- a/src/features/session-state.ts
+++ b/src/features/session-state.ts
@@ -748,8 +748,8 @@ function extractUserMessage(record: Record<string, unknown>): string | null {
 /**
  * Find transcript path for a session ID.
  */
-export function findTranscriptPathSync(sessionId: string): string | null {
-  const projectsDir = resolve(homedir(), '.claude/projects')
+export function findTranscriptPathSync(sessionId: string, sessionsDir?: string): string | null {
+  const projectsDir = sessionsDir ?? resolve(homedir(), '.claude/projects')
   try {
     const dirs = readdirSync(projectsDir, { withFileTypes: true })
     for (const dir of dirs) {

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -15,7 +15,7 @@ import { logActivity } from '../features/activity-log.js'
 import { saveSessionState, extractSessionStateFromTranscript, findTranscriptPathSync as findTranscriptSync } from '../features/session-state.js'
 import { readConfig } from '../config.js'
 import { loadCalibration } from '../features/calibration.js'
-import { readStdin, outputDecision, writeJsonFileAtomic, readJsonFile } from './shared.js'
+import { readStdin, outputDecision, writeJsonFileAtomic, readJsonFile, resolveProvider } from './shared.js'
 
 /**
  * PostToolUse hook handler.
@@ -59,6 +59,8 @@ export async function handlePostToolUseHook(): Promise<void> {
 async function processToolResult(input: PostToolUseHookInput): Promise<HookDecision> {
   const parts: string[] = []
   const hubPushes: Promise<void>[] = []
+  const provider = await resolveProvider()
+  const canonicalTool = provider.tools.toCanonical(input.tool_name)
 
   // Fire-and-forget hub push helper — scrubs secrets before sending
   function hubPush(cwd: string | null, fragments: Array<{ type: string; content: Record<string, unknown> }>) {
@@ -86,7 +88,7 @@ async function processToolResult(input: PostToolUseHookInput): Promise<HookDecis
 
 
   // 1. Compress bash output if applicable
-  if (input.tool_name === 'Bash') {
+  if (canonicalTool === 'bash_execute') {
     const toolResponse = input.tool_response || ''
     if (toolResponse.length >= 500) {
       const result = compressBashOutput(toolResponse)
@@ -203,7 +205,7 @@ async function processToolResult(input: PostToolUseHookInput): Promise<HookDecis
   }
 
   // 2. Detect repeated edits to the same file — a sign of thrashing
-  if (input.tool_name === 'Edit' || input.tool_name === 'Write') {
+  if (canonicalTool === 'file_edit' || canonicalTool === 'file_write') {
     const filePath = (input.tool_input?.file_path as string) || ''
     if (filePath) {
       const editWarning = trackFileEdits(input.session_id, filePath)
@@ -221,7 +223,7 @@ async function processToolResult(input: PostToolUseHookInput): Promise<HookDecis
   }
 
   // 2b. Track file reads + inject context for hot files + error cross-reference
-  if (input.tool_name === 'Read') {
+  if (canonicalTool === 'file_read') {
     const filePath = (input.tool_input?.file_path as string) || ''
     if (filePath && cwd) {
       try { recordFileRead(cwd, filePath, input.session_id) } catch {}
@@ -275,7 +277,7 @@ async function processToolResult(input: PostToolUseHookInput): Promise<HookDecis
   }
 
   // 2c. Gotcha injection for Read/View — fire-and-forget, rate-limited per file per session
-  if (input.tool_name === 'Read' || input.tool_name === 'View') {
+  if (canonicalTool === 'file_read') {
     const filePath = (input.tool_input?.file_path as string) || ''
     if (filePath && cwd && !hasCheckedGotcha(input.session_id, filePath)) {
       markGotchaChecked(input.session_id, filePath)
@@ -526,10 +528,11 @@ async function checkSessionHealth(sessionId: string): Promise<HookDecision | nul
 }
 
 /**
- * Find the transcript path for a session by scanning the projects directory.
+ * Find the transcript path for a session by scanning the provider's sessions directory.
  */
 async function findTranscriptPath(sessionId: string): Promise<string | null> {
-  const projectsDir = resolve(homedir(), '.claude/projects')
+  const provider = await resolveProvider()
+  const projectsDir = provider.directories.sessionsDir()
   try {
     const { readdir } = await import('node:fs/promises')
     const projectDirs = await readdir(projectsDir, { withFileTypes: true })

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -6,7 +6,7 @@ import { parseJsonlFile, extractTurns, extractModel } from '../daemon/parser.js'
 import { detectCacheDegradation } from '../features/cache-health.js'
 import { hasResumeBoundary, detectResumeAnomaly } from '../features/resume-detector.js'
 import { logActivity } from '../features/activity-log.js'
-import { readStdin, outputDecision, pruneStaleStateFiles } from './shared.js'
+import { readStdin, outputDecision, pruneStaleStateFiles, resolveProvider } from './shared.js'
 
 /**
  * SessionStart hook handler.
@@ -44,7 +44,8 @@ async function buildSessionStartContext(
 
   try {
     // Find recent sessions for this project
-    const projectsDir = resolve(homedir(), '.claude/projects')
+    const provider = await resolveProvider()
+    const projectsDir = provider.directories.sessionsDir()
     const recentIssues = await checkRecentSessions(projectsDir)
 
     if (recentIssues.length > 0) {

--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -3,6 +3,7 @@ import { resolve, dirname } from 'node:path'
 import { homedir } from 'node:os'
 import { randomBytes } from 'node:crypto'
 import type { HookDecision } from '../types.js'
+import type { Provider } from '../providers/types.js'
 
 /**
  * Read JSON from stdin — used by all hooks.
@@ -25,11 +26,31 @@ export function outputDecision(decision: HookDecision): void {
 }
 
 /**
- * Find transcript JSONL path for a session ID by scanning ~/.claude/projects/.
+ * Read the --provider flag from process.argv.
+ * Returns 'claude' if not specified.
+ */
+export function getProviderName(): string {
+  const idx = process.argv.indexOf('--provider')
+  return idx !== -1 && process.argv[idx + 1] ? process.argv[idx + 1] : 'claude'
+}
+
+/**
+ * Resolve the active provider from --provider CLI flag.
+ * Falls back to 'claude' if not specified.
+ * Async because ESM dynamic import is async.
+ */
+export async function resolveProvider(): Promise<Provider> {
+  const name = getProviderName()
+  const { registry } = await import('../providers/index.js')
+  return registry.get(name)
+}
+
+/**
+ * Find transcript path for a session ID by scanning the provider's sessions dir.
  * Synchronous — safe for hooks.
  */
-export function findTranscriptPathSync(sessionId: string): string | null {
-  const projectsDir = resolve(homedir(), '.claude/projects')
+export function findTranscriptPathSync(sessionId: string, sessionsDir?: string): string | null {
+  const projectsDir = sessionsDir ?? resolve(homedir(), '.claude/projects')
   try {
     const dirs = readdirSync(projectsDir, { withFileTypes: true })
     for (const dir of dirs) {

--- a/src/providers/aider/index.ts
+++ b/src/providers/aider/index.ts
@@ -1,0 +1,154 @@
+/**
+ * Aider provider (Tier 2 — session monitoring only, no hooks).
+ *
+ * Aider stores chat history as Markdown (.aider.chat.history.md)
+ * and reports token/cost inline in output.
+ */
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import { basename } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import type { Provider, SessionParser, SessionDiscovery, PricingResolver, ToolNameMapper, CanonicalTool, SessionContext } from '../types.js'
+import type { PricingConfig, SessionRecord, AssistantRecord, UserRecord, TurnMetrics, TokenUsage, ToolCallSummary } from '../../types.js'
+
+// Aider uses litellm and supports 100+ models — these are common defaults
+const AIDER_MODELS: Record<string, PricingConfig> = {
+  'claude-sonnet-4-6': { model: 'claude-sonnet-4-6', inputPerMillion: 3.0, outputPerMillion: 15.0, cacheCreationPerMillion: 3.75, cacheReadPerMillion: 0.3 },
+  'claude-opus-4-6': { model: 'claude-opus-4-6', inputPerMillion: 15.0, outputPerMillion: 75.0, cacheCreationPerMillion: 18.75, cacheReadPerMillion: 1.5 },
+  'gpt-4o': { model: 'gpt-4o', inputPerMillion: 2.5, outputPerMillion: 10.0, cacheCreationPerMillion: 3.125, cacheReadPerMillion: 1.25 },
+  'deepseek-chat': { model: 'deepseek-chat', inputPerMillion: 0.27, outputPerMillion: 1.10, cacheCreationPerMillion: 0.27, cacheReadPerMillion: 0.07 },
+}
+
+const pricing: PricingResolver = {
+  models: AIDER_MODELS,
+  defaultPricing: AIDER_MODELS['claude-sonnet-4-6'],
+  getPricing(modelId: string): PricingConfig {
+    for (const [key, p] of Object.entries(AIDER_MODELS)) { if (modelId.startsWith(key)) return p }
+    return this.defaultPricing
+  },
+}
+
+const tools: ToolNameMapper = {
+  toCanonical(name: string): CanonicalTool {
+    if (name === '/run' || name === 'bash') return 'bash_execute'
+    if (name === '/add' || name === 'edit') return 'file_edit'
+    return 'other'
+  },
+  fromCanonical(c: CanonicalTool): string { return c === 'bash_execute' ? '/run' : '/add' },
+  extractInputLabel(_t: string, input: unknown): string {
+    return typeof input === 'string' ? input.slice(0, 60) : ''
+  },
+}
+
+/**
+ * Parse Aider's markdown chat history.
+ * Format:
+ *   # aider chat started at 2025-05-07 17:24:21
+ *   > user message (blockquoted)
+ *   assistant response (plain text)
+ *   Tokens: 4.2k sent, 1.1k received. Cost: $0.03 message, $0.15 session.
+ */
+const parser: SessionParser = {
+  parseLine(line: string): SessionRecord | null { return null },
+
+  async parseFile(filePath: string): Promise<SessionRecord[]> {
+    const content = await readFile(filePath, 'utf-8')
+    const records: SessionRecord[] = []
+    const lines = content.split('\n')
+    let currentRole: 'user' | 'assistant' | null = null
+    let currentText = ''
+    let sessionTimestamp = new Date().toISOString()
+
+    for (const line of lines) {
+      // Session header
+      const headerMatch = line.match(/^# aider chat started at (.+)/)
+      if (headerMatch) {
+        sessionTimestamp = new Date(headerMatch[1]).toISOString()
+        continue
+      }
+
+      // Token/cost line
+      const tokenMatch = line.match(/Tokens:\s*([\d.]+)k sent.*?([\d.]+)k received.*?Cost:\s*\$([\d.]+)/)
+      if (tokenMatch) {
+        const sent = Math.round(parseFloat(tokenMatch[1]) * 1000)
+        const received = Math.round(parseFloat(tokenMatch[2]) * 1000)
+        records.push({
+          type: 'assistant', sessionId: '', timestamp: sessionTimestamp,
+          message: { role: 'assistant', model: '', content: [], usage: { input_tokens: sent, output_tokens: received, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } },
+        } as AssistantRecord)
+        continue
+      }
+
+      // User message (blockquoted)
+      if (line.startsWith('> ')) {
+        if (currentRole === 'assistant' && currentText.trim()) {
+          records.push({ type: 'assistant', sessionId: '', timestamp: sessionTimestamp, message: { role: 'assistant', model: '', content: [{ type: 'text', text: currentText.trim() }] } } as AssistantRecord)
+        }
+        currentRole = 'user'
+        currentText = line.slice(2) + '\n'
+        continue
+      }
+
+      // Transition from user to assistant
+      if (currentRole === 'user' && !line.startsWith('> ') && line.trim()) {
+        records.push({ type: 'user', sessionId: '', timestamp: sessionTimestamp, message: { role: 'user', content: currentText.trim() } } as UserRecord)
+        currentRole = 'assistant'
+        currentText = line + '\n'
+        continue
+      }
+
+      if (currentRole) currentText += line + '\n'
+    }
+
+    // Flush remaining
+    if (currentRole === 'assistant' && currentText.trim()) {
+      records.push({ type: 'assistant', sessionId: '', timestamp: sessionTimestamp, message: { role: 'assistant', model: '', content: [{ type: 'text', text: currentText.trim() }] } } as AssistantRecord)
+    } else if (currentRole === 'user' && currentText.trim()) {
+      records.push({ type: 'user', sessionId: '', timestamp: sessionTimestamp, message: { role: 'user', content: currentText.trim() } } as UserRecord)
+    }
+
+    return records
+  },
+
+  extractTurns(records: SessionRecord[]): TurnMetrics[] {
+    const turns: TurnMetrics[] = []
+    let idx = 0
+    for (const r of records) {
+      if (r.type !== 'assistant') continue
+      const a = r as AssistantRecord
+      if (!a.message?.usage) continue
+      const u = a.message.usage
+      turns.push({ turnIndex: idx++, timestamp: a.timestamp, usage: u, cacheRatio: 0, toolCalls: [] })
+    }
+    return turns
+  },
+  extractModel(): string | null { return null },
+  extractContext(): SessionContext { return { cwd: null, gitBranch: null, projectName: null, firstUserMessage: null } },
+  hasResumeBoundary(): boolean { return false },
+}
+
+const discovery: SessionDiscovery = {
+  fileExtensions: ['.md'],
+  watchDepth: 1,
+  extractSessionId(fp: string): string { return basename(fp).replace('.md', '') },
+  extractProjectPath(): string { return 'aider' },
+}
+
+export const aiderProvider: Provider = {
+  name: 'aider',
+  displayName: 'Aider',
+  tier: 2,
+  directories: {
+    sessionsDir: () => process.cwd(), // Aider stores .aider.chat.history.md in project root
+    configDir: () => resolve(homedir(), '.aider'),
+    stateDir: () => resolve(homedir(), '.clauditor'),
+  },
+  parser, discovery, pricing, tools,
+  hooks: null,
+  getContextLimit(model: string): number {
+    if (model.includes('opus')) return 1_000_000
+    if (model.includes('claude')) return 200_000
+    if (model.includes('gpt-4o')) return 128_000
+    return 128_000
+  },
+}

--- a/src/providers/amazonq/index.ts
+++ b/src/providers/amazonq/index.ts
@@ -1,0 +1,61 @@
+/**
+ * Amazon Q Developer provider (Tier 3 — limited monitoring).
+ *
+ * Amazon Q stores sessions in ~/.aws/amazonq/.
+ * No user-level hook system — it's a managed service.
+ */
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import { basename } from 'node:path'
+import type { Provider, SessionParser, SessionDiscovery, PricingResolver, ToolNameMapper, CanonicalTool, SessionContext } from '../types.js'
+import type { PricingConfig, SessionRecord, TurnMetrics } from '../../types.js'
+
+// Amazon Q is subscription-based
+const AQ_MODELS: Record<string, PricingConfig> = {
+  'amazonq-default': { model: 'amazonq-default', inputPerMillion: 0, outputPerMillion: 0, cacheCreationPerMillion: 0, cacheReadPerMillion: 0 },
+}
+
+const pricing: PricingResolver = {
+  models: AQ_MODELS,
+  defaultPricing: AQ_MODELS['amazonq-default'],
+  getPricing(): PricingConfig { return this.defaultPricing },
+}
+
+const tools: ToolNameMapper = {
+  toCanonical(name: string): CanonicalTool {
+    const map: Record<string, CanonicalTool> = { fs_read: 'file_read', fs_write: 'file_write', execute_bash: 'bash_execute', use_aws: 'other' }
+    return map[name] ?? 'other'
+  },
+  fromCanonical(c: CanonicalTool): string { return c === 'bash_execute' ? 'execute_bash' : 'fs_read' },
+  extractInputLabel(): string { return '' },
+}
+
+const parser: SessionParser = {
+  parseLine(): SessionRecord | null { return null },
+  async parseFile(): Promise<SessionRecord[]> { return [] },
+  extractTurns(): TurnMetrics[] { return [] },
+  extractModel(): string | null { return null },
+  extractContext(): SessionContext { return { cwd: null, gitBranch: null, projectName: null, firstUserMessage: null } },
+  hasResumeBoundary(): boolean { return false },
+}
+
+const discovery: SessionDiscovery = {
+  fileExtensions: ['.json'],
+  watchDepth: 2,
+  extractSessionId(fp: string): string { return basename(fp).replace('.json', '') },
+  extractProjectPath(): string { return 'amazonq' },
+}
+
+export const amazonqProvider: Provider = {
+  name: 'amazonq',
+  displayName: 'Amazon Q Developer',
+  tier: 3,
+  directories: {
+    sessionsDir: () => resolve(homedir(), '.aws/amazonq'),
+    configDir: () => resolve(homedir(), '.aws/amazonq'),
+    stateDir: () => resolve(homedir(), '.clauditor'),
+  },
+  parser, discovery, pricing, tools,
+  hooks: null,
+  getContextLimit(): number { return 128_000 },
+}

--- a/src/providers/claude/discovery.ts
+++ b/src/providers/claude/discovery.ts
@@ -1,0 +1,19 @@
+import { basename, sep } from 'node:path'
+import type { SessionDiscovery } from '../types.js'
+
+export const claudeDiscovery: SessionDiscovery = {
+  fileExtensions: ['.jsonl'],
+  watchDepth: 4,
+
+  extractSessionId(filePath: string): string {
+    return basename(filePath).replace('.jsonl', '')
+  },
+
+  extractProjectPath(filePath: string, baseDir: string): string {
+    const relative = filePath
+      .replace(baseDir + sep, '')
+      .replace(baseDir + '/', '')
+    const parts = relative.split(sep)
+    return parts[0] || 'unknown'
+  },
+}

--- a/src/providers/claude/hooks.ts
+++ b/src/providers/claude/hooks.ts
@@ -1,0 +1,46 @@
+/**
+ * Claude Code hook manager — installs/uninstalls clauditor hooks
+ * into ~/.claude/settings.json.
+ */
+import type { HookManager, CanonicalHookEvent } from '../types.js'
+import type { HookDecision } from '../../types.js'
+import { installHooks, uninstallHooks } from '../../install.js'
+
+const EVENT_MAP: Record<CanonicalHookEvent, string> = {
+  session_start: 'SessionStart',
+  user_prompt_submit: 'UserPromptSubmit',
+  pre_tool_use: 'PreToolUse',
+  post_tool_use: 'PostToolUse',
+  pre_compact: 'PreCompact',
+  post_compact: 'PostCompact',
+  stop: 'Stop',
+}
+
+export const claudeHooks: HookManager = {
+  supportedEvents: [
+    'session_start',
+    'user_prompt_submit',
+    'post_tool_use',
+    'pre_compact',
+    'post_compact',
+    'stop',
+  ] as CanonicalHookEvent[],
+
+  blockExitCode: 2,
+
+  eventName(canonical: CanonicalHookEvent): string | null {
+    return EVENT_MAP[canonical] ?? null
+  },
+
+  async install(): Promise<string[]> {
+    return installHooks()
+  },
+
+  async uninstall(): Promise<string[]> {
+    return uninstallHooks()
+  },
+
+  formatOutput(decision: HookDecision): string {
+    return JSON.stringify(decision)
+  },
+}

--- a/src/providers/claude/index.ts
+++ b/src/providers/claude/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Claude Code provider — the original and primary clauditor integration.
+ */
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import type { Provider } from '../types.js'
+import { claudeParser } from './parser.js'
+import { claudeDiscovery } from './discovery.js'
+import { claudePricing } from './pricing.js'
+import { claudeTools } from './tools.js'
+import { claudeHooks } from './hooks.js'
+
+export const claudeProvider: Provider = {
+  name: 'claude',
+  displayName: 'Claude Code',
+  tier: 1,
+
+  directories: {
+    sessionsDir: () => resolve(homedir(), '.claude/projects'),
+    configDir: () => resolve(homedir(), '.claude'),
+    stateDir: () => resolve(homedir(), '.clauditor'),
+  },
+
+  parser: claudeParser,
+  discovery: claudeDiscovery,
+  pricing: claudePricing,
+  tools: claudeTools,
+  hooks: claudeHooks,
+
+  getContextLimit(model: string): number {
+    if (model.includes('opus')) return 1_000_000
+    if (model.includes('haiku')) return 200_000
+    return 200_000 // Sonnet default
+  },
+}

--- a/src/providers/claude/parser.ts
+++ b/src/providers/claude/parser.ts
@@ -1,0 +1,40 @@
+/**
+ * Claude Code session parser — wraps the existing daemon/parser.ts functions
+ * to implement the SessionParser interface.
+ */
+import type { SessionParser, SessionContext } from '../types.js'
+import type { SessionRecord, TurnMetrics } from '../../types.js'
+import {
+  parseJsonlLine,
+  parseJsonlFile,
+  extractTurns,
+  extractModel,
+  extractSessionContext,
+} from '../../daemon/parser.js'
+import { hasResumeBoundary } from '../../features/resume-detector.js'
+
+export const claudeParser: SessionParser = {
+  parseLine(line: string): SessionRecord | null {
+    return parseJsonlLine(line)
+  },
+
+  parseFile(filePath: string): Promise<SessionRecord[]> {
+    return parseJsonlFile(filePath)
+  },
+
+  extractTurns(records: SessionRecord[]): TurnMetrics[] {
+    return extractTurns(records)
+  },
+
+  extractModel(records: SessionRecord[]): string | null {
+    return extractModel(records)
+  },
+
+  extractContext(records: SessionRecord[]): SessionContext {
+    return extractSessionContext(records)
+  },
+
+  hasResumeBoundary(records: SessionRecord[]): boolean {
+    return hasResumeBoundary(records)
+  },
+}

--- a/src/providers/claude/pricing.ts
+++ b/src/providers/claude/pricing.ts
@@ -1,0 +1,37 @@
+import type { PricingConfig } from '../../types.js'
+import type { PricingResolver } from '../types.js'
+
+export const CLAUDE_MODELS: Record<string, PricingConfig> = {
+  'claude-sonnet-4-6': {
+    model: 'claude-sonnet-4-6',
+    inputPerMillion: 3.0,
+    outputPerMillion: 15.0,
+    cacheCreationPerMillion: 3.75,
+    cacheReadPerMillion: 0.3,
+  },
+  'claude-opus-4-6': {
+    model: 'claude-opus-4-6',
+    inputPerMillion: 15.0,
+    outputPerMillion: 75.0,
+    cacheCreationPerMillion: 18.75,
+    cacheReadPerMillion: 1.5,
+  },
+  'claude-haiku-4-5': {
+    model: 'claude-haiku-4-5',
+    inputPerMillion: 0.8,
+    outputPerMillion: 4.0,
+    cacheCreationPerMillion: 1.0,
+    cacheReadPerMillion: 0.08,
+  },
+}
+
+export const claudePricing: PricingResolver = {
+  models: CLAUDE_MODELS,
+  defaultPricing: CLAUDE_MODELS['claude-sonnet-4-6'],
+  getPricing(modelId: string): PricingConfig {
+    for (const [key, pricing] of Object.entries(CLAUDE_MODELS)) {
+      if (modelId.startsWith(key)) return pricing
+    }
+    return this.defaultPricing
+  },
+}

--- a/src/providers/claude/tools.ts
+++ b/src/providers/claude/tools.ts
@@ -1,0 +1,58 @@
+import type { ToolNameMapper, CanonicalTool } from '../types.js'
+
+const TOOL_MAP: Record<string, CanonicalTool> = {
+  Bash: 'bash_execute',
+  Read: 'file_read',
+  Write: 'file_write',
+  Edit: 'file_edit',
+  Glob: 'file_search',
+  Grep: 'file_search',
+  View: 'file_read',
+  WebSearch: 'web_search',
+  WebFetch: 'web_fetch',
+  Agent: 'other',
+  NotebookEdit: 'file_edit',
+}
+
+const REVERSE_MAP: Record<CanonicalTool, string> = {
+  bash_execute: 'Bash',
+  file_read: 'Read',
+  file_write: 'Write',
+  file_edit: 'Edit',
+  file_search: 'Grep',
+  web_search: 'WebSearch',
+  web_fetch: 'WebFetch',
+  browser: 'Bash',
+  mcp_tool: 'Bash',
+  other: 'Bash',
+}
+
+export const claudeTools: ToolNameMapper = {
+  toCanonical(providerToolName: string): CanonicalTool {
+    return TOOL_MAP[providerToolName] ?? 'other'
+  },
+
+  fromCanonical(canonical: CanonicalTool): string {
+    return REVERSE_MAP[canonical] ?? 'Bash'
+  },
+
+  extractInputLabel(toolName: string, input: unknown): string {
+    if (!input || typeof input !== 'object') return ''
+    const obj = input as Record<string, unknown>
+
+    switch (toolName) {
+      case 'Bash': {
+        const cmd = typeof obj.command === 'string' ? obj.command : ''
+        return cmd.split('\n')[0].trim().slice(0, 60)
+      }
+      case 'Read':
+      case 'Edit':
+      case 'Write': {
+        const fp = typeof obj.file_path === 'string' ? obj.file_path : ''
+        return fp.split(/[/\\]/).pop() || ''
+      }
+      default:
+        return ''
+    }
+  },
+}

--- a/src/providers/cline/discovery.ts
+++ b/src/providers/cline/discovery.ts
@@ -1,0 +1,16 @@
+import { basename, dirname } from 'node:path'
+import type { SessionDiscovery } from '../types.js'
+
+export const clineDiscovery: SessionDiscovery = {
+  fileExtensions: ['.json'],
+  watchDepth: 3,
+
+  extractSessionId(filePath: string): string {
+    // Task dirs: globalStorage/tasks/<taskId>/api_conversation_history.json
+    return basename(dirname(filePath))
+  },
+
+  extractProjectPath(filePath: string, _baseDir: string): string {
+    return 'cline'
+  },
+}

--- a/src/providers/cline/hooks.ts
+++ b/src/providers/cline/hooks.ts
@@ -1,0 +1,111 @@
+/**
+ * Cline hook manager — installs/uninstalls clauditor hooks
+ * into .clinerules/hooks/ directory.
+ *
+ * Cline hooks are scripts discovered from:
+ * 1. .clinerules/hooks/ (workspace)
+ * 2. ~/Documents/Cline/Hooks/ (global)
+ *
+ * Hook output: { cancel: boolean, contextModification: string, errorMessage: string }
+ */
+import { writeFile, mkdir, readdir, unlink } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import type { HookManager, CanonicalHookEvent } from '../types.js'
+import type { HookDecision } from '../../types.js'
+
+const GLOBAL_HOOKS_DIR = resolve(homedir(), 'Documents/Cline/Hooks')
+const CLAUDITOR_PREFIX = 'clauditor-'
+
+const EVENT_MAP: Record<CanonicalHookEvent, string | null> = {
+  session_start: 'TaskStart',
+  user_prompt_submit: 'UserPromptSubmit',
+  pre_tool_use: 'PreToolUse',
+  post_tool_use: 'PostToolUse',
+  pre_compact: 'PreCompact',
+  post_compact: null,
+  stop: 'TaskComplete',
+}
+
+function getHookCommand(subcommand: string): string {
+  const isNpx = process.argv[1]?.includes('_npx') || process.env.npm_execpath?.includes('npx')
+  if (isNpx) {
+    return `npx -y @iyadhk/clauditor hook ${subcommand} --provider cline`
+  }
+  return `clauditor hook ${subcommand} --provider cline`
+}
+
+const HOOK_SCRIPTS: Record<string, { filename: string; command: string }> = {
+  PreToolUse: { filename: `${CLAUDITOR_PREFIX}pre-tool-use.sh`, command: getHookCommand('pre-tool-use') },
+  PostToolUse: { filename: `${CLAUDITOR_PREFIX}post-tool-use.sh`, command: getHookCommand('post-tool-use') },
+  UserPromptSubmit: { filename: `${CLAUDITOR_PREFIX}user-prompt-submit.sh`, command: getHookCommand('user-prompt-submit') },
+  TaskStart: { filename: `${CLAUDITOR_PREFIX}session-start.sh`, command: getHookCommand('session-start') },
+  TaskComplete: { filename: `${CLAUDITOR_PREFIX}stop.sh`, command: getHookCommand('stop') },
+}
+
+export const clineHooks: HookManager = {
+  supportedEvents: [
+    'session_start',
+    'user_prompt_submit',
+    'pre_tool_use',
+    'post_tool_use',
+    'pre_compact',
+    'stop',
+  ] as CanonicalHookEvent[],
+
+  blockExitCode: 1, // Cline uses { cancel: true } in output
+
+  eventName(canonical: CanonicalHookEvent): string | null {
+    return EVENT_MAP[canonical] ?? null
+  },
+
+  async install(): Promise<string[]> {
+    const messages: string[] = []
+    await mkdir(GLOBAL_HOOKS_DIR, { recursive: true })
+
+    for (const [eventName, script] of Object.entries(HOOK_SCRIPTS)) {
+      const scriptPath = resolve(GLOBAL_HOOKS_DIR, script.filename)
+      const content = `#!/bin/bash\n# Clauditor hook for Cline ${eventName}\n${script.command}\n`
+
+      await writeFile(scriptPath, content, { mode: 0o755 })
+      messages.push(`${eventName}: ✓ installed (${script.filename})`)
+    }
+
+    messages.push(`\nHook scripts written to ${GLOBAL_HOOKS_DIR}`)
+    return messages
+  },
+
+  async uninstall(): Promise<string[]> {
+    const messages: string[] = []
+
+    try {
+      const files = await readdir(GLOBAL_HOOKS_DIR)
+      for (const file of files) {
+        if (file.startsWith(CLAUDITOR_PREFIX)) {
+          await unlink(resolve(GLOBAL_HOOKS_DIR, file))
+          messages.push(`✓ removed ${file}`)
+        }
+      }
+    } catch {
+      messages.push('No clauditor hooks found')
+    }
+
+    return messages
+  },
+
+  formatOutput(decision: HookDecision): string {
+    if (decision.decision === 'block') {
+      return JSON.stringify({
+        cancel: true,
+        errorMessage: decision.reason || 'Blocked by clauditor',
+      })
+    }
+    if (decision.additionalContext) {
+      return JSON.stringify({
+        cancel: false,
+        contextModification: decision.additionalContext,
+      })
+    }
+    return JSON.stringify({ cancel: false })
+  },
+}

--- a/src/providers/cline/index.ts
+++ b/src/providers/cline/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Cline (and Roo Code) VS Code extension provider.
+ *
+ * Cline stores tasks as JSON in VS Code globalStorage with:
+ * - api_conversation_history.json (Anthropic MessageParam format)
+ * - 9 hook events via .clinerules/hooks/ scripts
+ * - Rich tool set (execute_command, read_file, write_to_file, etc.)
+ */
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import type { Provider } from '../types.js'
+import { clineParser } from './parser.js'
+import { clineDiscovery } from './discovery.js'
+import { clinePricing } from './pricing.js'
+import { clineTools } from './tools.js'
+import { clineHooks } from './hooks.js'
+
+function getClineStorageDir(): string {
+  if (process.platform === 'darwin') {
+    return resolve(homedir(), 'Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev')
+  }
+  if (process.platform === 'win32') {
+    return resolve(process.env.APPDATA || homedir(), 'Code/User/globalStorage/saoudrizwan.claude-dev')
+  }
+  return resolve(homedir(), '.vscode/extensions/globalStorage/saoudrizwan.claude-dev')
+}
+
+export const clineProvider: Provider = {
+  name: 'cline',
+  displayName: 'Cline',
+  tier: 1,
+
+  directories: {
+    sessionsDir: () => resolve(getClineStorageDir(), 'tasks'),
+    configDir: () => getClineStorageDir(),
+    stateDir: () => resolve(homedir(), '.clauditor'),
+  },
+
+  parser: clineParser,
+  discovery: clineDiscovery,
+  pricing: clinePricing,
+  tools: clineTools,
+  hooks: clineHooks,
+
+  getContextLimit(model: string): number {
+    if (model.includes('opus')) return 1_000_000
+    if (model.includes('claude')) return 200_000
+    if (model.includes('gpt-4o')) return 128_000
+    if (model.includes('gemini')) return 1_000_000
+    if (model.includes('deepseek')) return 128_000
+    return 200_000
+  },
+}

--- a/src/providers/cline/parser.ts
+++ b/src/providers/cline/parser.ts
@@ -1,0 +1,142 @@
+/**
+ * Cline/Roo Code session parser.
+ *
+ * Cline stores conversations as api_conversation_history.json in VS Code
+ * globalStorage. The format is an array of Anthropic MessageParam objects.
+ */
+import { readFile } from 'node:fs/promises'
+import type { SessionRecord, AssistantRecord, UserRecord, TurnMetrics, TokenUsage, ToolCallSummary, ContentBlock } from '../../types.js'
+import type { SessionParser, SessionContext } from '../types.js'
+
+export const clineParser: SessionParser = {
+  parseLine(line: string): SessionRecord | null {
+    const trimmed = line.trim()
+    if (!trimmed) return null
+    try {
+      return JSON.parse(trimmed)
+    } catch {
+      return null
+    }
+  },
+
+  async parseFile(filePath: string): Promise<SessionRecord[]> {
+    const content = await readFile(filePath, 'utf-8')
+    const records: SessionRecord[] = []
+
+    try {
+      const messages = JSON.parse(content)
+      if (!Array.isArray(messages)) return records
+
+      for (const msg of messages) {
+        if (!msg.role) continue
+        const timestamp = msg.ts ? new Date(msg.ts).toISOString() : new Date().toISOString()
+
+        if (msg.role === 'user') {
+          records.push({
+            type: 'user',
+            sessionId: '',
+            timestamp,
+            message: { role: 'user', content: msg.content || '' },
+          } as UserRecord)
+        } else if (msg.role === 'assistant') {
+          const contentBlocks: ContentBlock[] = []
+          if (Array.isArray(msg.content)) {
+            for (const block of msg.content) {
+              if (block.type === 'text') {
+                contentBlocks.push({ type: 'text', text: block.text || '' })
+              } else if (block.type === 'tool_use') {
+                contentBlocks.push({
+                  type: 'tool_use',
+                  name: block.name || 'unknown',
+                  id: block.id || '',
+                  input: block.input,
+                })
+              }
+            }
+          } else if (typeof msg.content === 'string') {
+            contentBlocks.push({ type: 'text', text: msg.content })
+          }
+
+          records.push({
+            type: 'assistant',
+            sessionId: '',
+            timestamp,
+            message: {
+              role: 'assistant',
+              model: msg.model || '',
+              content: contentBlocks,
+              usage: msg.usage ? {
+                input_tokens: msg.usage.input_tokens || 0,
+                output_tokens: msg.usage.output_tokens || 0,
+                cache_creation_input_tokens: msg.usage.cache_creation_input_tokens || 0,
+                cache_read_input_tokens: msg.usage.cache_read_input_tokens || 0,
+              } : undefined,
+            },
+          } as AssistantRecord)
+        }
+      }
+    } catch {
+      // Not valid JSON array — might be JSONL
+      for (const line of content.split('\n')) {
+        const record = clineParser.parseLine(line)
+        if (record) records.push(record)
+      }
+    }
+
+    return records
+  },
+
+  extractTurns(records: SessionRecord[]): TurnMetrics[] {
+    const turns: TurnMetrics[] = []
+    let turnIndex = 0
+
+    for (const record of records) {
+      if (record.type !== 'assistant') continue
+      const assistant = record as AssistantRecord
+      if (!assistant.message?.usage) continue
+
+      const usage = normalizeUsage(assistant.message.usage)
+      const totalInput = usage.input_tokens + usage.cache_creation_input_tokens + usage.cache_read_input_tokens
+      const cacheRatio = totalInput > 0 ? usage.cache_read_input_tokens / totalInput : 0
+
+      const toolCalls: ToolCallSummary[] = (assistant.message.content || [])
+        .filter(block => block.type === 'tool_use')
+        .map(block => ({
+          name: block.name || 'unknown',
+          inputHash: '',
+          outputHash: '',
+        }))
+
+      turns.push({ turnIndex: turnIndex++, timestamp: assistant.timestamp, usage, cacheRatio, toolCalls })
+    }
+    return turns
+  },
+
+  extractModel(records: SessionRecord[]): string | null {
+    for (let i = records.length - 1; i >= 0; i--) {
+      const r = records[i]
+      if (r.type === 'assistant') {
+        const model = (r as AssistantRecord).message?.model
+        if (model) return model
+      }
+    }
+    return null
+  },
+
+  extractContext(records: SessionRecord[]): SessionContext {
+    return { cwd: null, gitBranch: null, projectName: null, firstUserMessage: null }
+  },
+
+  hasResumeBoundary(records: SessionRecord[]): boolean {
+    return false // Cline doesn't have compaction boundaries
+  },
+}
+
+function normalizeUsage(usage: Partial<TokenUsage>): TokenUsage {
+  return {
+    input_tokens: usage.input_tokens ?? 0,
+    output_tokens: usage.output_tokens ?? 0,
+    cache_creation_input_tokens: usage.cache_creation_input_tokens ?? 0,
+    cache_read_input_tokens: usage.cache_read_input_tokens ?? 0,
+  }
+}

--- a/src/providers/cline/pricing.ts
+++ b/src/providers/cline/pricing.ts
@@ -1,0 +1,52 @@
+import type { PricingConfig } from '../../types.js'
+import type { PricingResolver } from '../types.js'
+
+/** Cline supports many providers — these are the most common models used. */
+export const CLINE_MODELS: Record<string, PricingConfig> = {
+  'claude-sonnet-4-6': {
+    model: 'claude-sonnet-4-6',
+    inputPerMillion: 3.0,
+    outputPerMillion: 15.0,
+    cacheCreationPerMillion: 3.75,
+    cacheReadPerMillion: 0.3,
+  },
+  'claude-opus-4-6': {
+    model: 'claude-opus-4-6',
+    inputPerMillion: 15.0,
+    outputPerMillion: 75.0,
+    cacheCreationPerMillion: 18.75,
+    cacheReadPerMillion: 1.5,
+  },
+  'gpt-4o': {
+    model: 'gpt-4o',
+    inputPerMillion: 2.5,
+    outputPerMillion: 10.0,
+    cacheCreationPerMillion: 3.125,
+    cacheReadPerMillion: 1.25,
+  },
+  'gemini-2.5-pro': {
+    model: 'gemini-2.5-pro',
+    inputPerMillion: 1.25,
+    outputPerMillion: 10.0,
+    cacheCreationPerMillion: 1.5625,
+    cacheReadPerMillion: 0.3125,
+  },
+  'deepseek-chat': {
+    model: 'deepseek-chat',
+    inputPerMillion: 0.27,
+    outputPerMillion: 1.10,
+    cacheCreationPerMillion: 0.27,
+    cacheReadPerMillion: 0.07,
+  },
+}
+
+export const clinePricing: PricingResolver = {
+  models: CLINE_MODELS,
+  defaultPricing: CLINE_MODELS['claude-sonnet-4-6'],
+  getPricing(modelId: string): PricingConfig {
+    for (const [key, pricing] of Object.entries(CLINE_MODELS)) {
+      if (modelId.startsWith(key)) return pricing
+    }
+    return this.defaultPricing
+  },
+}

--- a/src/providers/cline/tools.ts
+++ b/src/providers/cline/tools.ts
@@ -1,0 +1,62 @@
+import type { ToolNameMapper, CanonicalTool } from '../types.js'
+
+const TOOL_MAP: Record<string, CanonicalTool> = {
+  execute_command: 'bash_execute',
+  read_file: 'file_read',
+  write_to_file: 'file_write',
+  replace_in_file: 'file_edit',
+  apply_patch: 'file_edit',
+  search_files: 'file_search',
+  list_files: 'file_search',
+  list_code_definition_names: 'file_search',
+  browser_action: 'browser',
+  use_mcp_tool: 'mcp_tool',
+  access_mcp_resource: 'mcp_tool',
+  web_fetch: 'web_fetch',
+  web_search: 'web_search',
+  ask_followup_question: 'other',
+  attempt_completion: 'other',
+  new_task: 'other',
+  use_skill: 'other',
+  use_subagents: 'other',
+}
+
+const REVERSE_MAP: Record<CanonicalTool, string> = {
+  bash_execute: 'execute_command',
+  file_read: 'read_file',
+  file_write: 'write_to_file',
+  file_edit: 'replace_in_file',
+  file_search: 'search_files',
+  web_search: 'web_search',
+  web_fetch: 'web_fetch',
+  browser: 'browser_action',
+  mcp_tool: 'use_mcp_tool',
+  other: 'execute_command',
+}
+
+export const clineTools: ToolNameMapper = {
+  toCanonical(providerToolName: string): CanonicalTool {
+    return TOOL_MAP[providerToolName] ?? 'other'
+  },
+  fromCanonical(canonical: CanonicalTool): string {
+    return REVERSE_MAP[canonical] ?? 'execute_command'
+  },
+  extractInputLabel(toolName: string, input: unknown): string {
+    if (!input || typeof input !== 'object') return ''
+    const obj = input as Record<string, unknown>
+    switch (toolName) {
+      case 'execute_command': {
+        const cmd = typeof obj.command === 'string' ? obj.command : ''
+        return cmd.split('\n')[0].trim().slice(0, 60)
+      }
+      case 'read_file':
+      case 'write_to_file':
+      case 'replace_in_file': {
+        const fp = typeof obj.path === 'string' ? obj.path : ''
+        return fp.split(/[/\\]/).pop() || ''
+      }
+      default:
+        return ''
+    }
+  },
+}

--- a/src/providers/codex/discovery.ts
+++ b/src/providers/codex/discovery.ts
@@ -1,0 +1,17 @@
+import { basename } from 'node:path'
+import type { SessionDiscovery } from '../types.js'
+
+export const codexDiscovery: SessionDiscovery = {
+  fileExtensions: ['.jsonl'],
+  watchDepth: 2, // ~/.codex/sessions/ is flat or has archived/
+
+  extractSessionId(filePath: string): string {
+    // Codex files: rollout-2025-05-07T17-24-21-<uuid>.jsonl
+    return basename(filePath).replace('.jsonl', '')
+  },
+
+  extractProjectPath(filePath: string, _baseDir: string): string {
+    // Codex doesn't organize by project — use the session meta's cwd
+    return 'codex'
+  },
+}

--- a/src/providers/codex/hooks.ts
+++ b/src/providers/codex/hooks.ts
@@ -1,0 +1,137 @@
+/**
+ * Codex CLI hook manager — installs/uninstalls clauditor hooks
+ * into ~/.codex/hooks.json.
+ *
+ * Codex uses the same 5 hook events as Claude Code with a nearly
+ * identical format — the main difference is the config file location
+ * and the JSON structure.
+ */
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { homedir } from 'node:os'
+import type { HookManager, CanonicalHookEvent } from '../types.js'
+import type { HookDecision } from '../../types.js'
+
+const CODEX_HOOKS_PATH = resolve(homedir(), '.codex/hooks.json')
+const CLAUDITOR_MARKER = 'clauditor hook'
+
+const EVENT_MAP: Record<CanonicalHookEvent, string | null> = {
+  session_start: 'SessionStart',
+  user_prompt_submit: 'UserPromptSubmit',
+  pre_tool_use: 'PreToolUse',
+  post_tool_use: 'PostToolUse',
+  pre_compact: null, // Codex doesn't have pre/post compact
+  post_compact: null,
+  stop: 'Stop',
+}
+
+interface CodexHookEntry {
+  matcher?: string
+  hooks: Array<{ type: 'command'; command: string; timeoutSec?: number }>
+}
+
+interface CodexHooksFile {
+  hooks: Record<string, CodexHookEntry[]>
+}
+
+function getHookCommand(subcommand: string): string {
+  const isNpx = process.argv[1]?.includes('_npx') || process.env.npm_execpath?.includes('npx')
+  if (isNpx) {
+    return `npx -y @iyadhk/clauditor hook ${subcommand} --provider codex`
+  }
+  return `clauditor hook ${subcommand} --provider codex`
+}
+
+const HOOK_COMMANDS: Record<string, string> = {
+  UserPromptSubmit: getHookCommand('user-prompt-submit'),
+  PreToolUse: getHookCommand('pre-tool-use'),
+  PostToolUse: getHookCommand('post-tool-use'),
+  SessionStart: getHookCommand('session-start'),
+  Stop: getHookCommand('stop'),
+}
+
+async function readHooksFile(): Promise<CodexHooksFile> {
+  try {
+    const content = await readFile(CODEX_HOOKS_PATH, 'utf-8')
+    return JSON.parse(content)
+  } catch {
+    return { hooks: {} }
+  }
+}
+
+async function writeHooksFile(data: CodexHooksFile): Promise<void> {
+  await mkdir(dirname(CODEX_HOOKS_PATH), { recursive: true })
+  await writeFile(CODEX_HOOKS_PATH, JSON.stringify(data, null, 2) + '\n')
+}
+
+export const codexHooks: HookManager = {
+  supportedEvents: [
+    'session_start',
+    'user_prompt_submit',
+    'pre_tool_use',
+    'post_tool_use',
+    'stop',
+  ] as CanonicalHookEvent[],
+
+  blockExitCode: 2,
+
+  eventName(canonical: CanonicalHookEvent): string | null {
+    return EVENT_MAP[canonical] ?? null
+  },
+
+  async install(): Promise<string[]> {
+    const file = await readHooksFile()
+    const messages: string[] = []
+
+    for (const [eventName, command] of Object.entries(HOOK_COMMANDS)) {
+      if (!file.hooks[eventName]) {
+        file.hooks[eventName] = []
+      }
+
+      const alreadyInstalled = file.hooks[eventName].some(entry =>
+        entry.hooks.some(h => h.command.includes(CLAUDITOR_MARKER))
+      )
+
+      if (alreadyInstalled) {
+        messages.push(`${eventName}: already installed (skipped)`)
+        continue
+      }
+
+      file.hooks[eventName].push({
+        hooks: [{ type: 'command', command }],
+      })
+      messages.push(`${eventName}: ✓ installed`)
+    }
+
+    await writeHooksFile(file)
+    messages.push(`\nHooks written to ${CODEX_HOOKS_PATH}`)
+    return messages
+  },
+
+  async uninstall(): Promise<string[]> {
+    const file = await readHooksFile()
+    const messages: string[] = []
+
+    for (const eventName of Object.keys(file.hooks)) {
+      const before = file.hooks[eventName].length
+      file.hooks[eventName] = file.hooks[eventName].filter(
+        entry => !entry.hooks.some(h => h.command.includes(CLAUDITOR_MARKER))
+      )
+      const removed = before - file.hooks[eventName].length
+      if (removed > 0) {
+        messages.push(`${eventName}: ✓ removed ${removed} clauditor hook(s)`)
+      }
+      if (file.hooks[eventName].length === 0) {
+        delete file.hooks[eventName]
+      }
+    }
+
+    await writeHooksFile(file)
+    messages.push(`\nHooks written to ${CODEX_HOOKS_PATH}`)
+    return messages
+  },
+
+  formatOutput(decision: HookDecision): string {
+    return JSON.stringify(decision)
+  },
+}

--- a/src/providers/codex/index.ts
+++ b/src/providers/codex/index.ts
@@ -1,0 +1,41 @@
+/**
+ * OpenAI Codex CLI provider.
+ *
+ * Codex has a nearly identical architecture to Claude Code:
+ * - JSONL session files in ~/.codex/sessions/
+ * - Same 5 hook events (PreToolUse, PostToolUse, UserPromptSubmit, SessionStart, Stop)
+ * - hooks.json config format (vs Claude's settings.json)
+ */
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import type { Provider } from '../types.js'
+import { codexParser } from './parser.js'
+import { codexDiscovery } from './discovery.js'
+import { codexPricing } from './pricing.js'
+import { codexTools } from './tools.js'
+import { codexHooks } from './hooks.js'
+
+export const codexProvider: Provider = {
+  name: 'codex',
+  displayName: 'Codex CLI',
+  tier: 1,
+
+  directories: {
+    sessionsDir: () => resolve(homedir(), '.codex/sessions'),
+    configDir: () => resolve(homedir(), '.codex'),
+    stateDir: () => resolve(homedir(), '.clauditor'),
+  },
+
+  parser: codexParser,
+  discovery: codexDiscovery,
+  pricing: codexPricing,
+  tools: codexTools,
+  hooks: codexHooks,
+
+  getContextLimit(model: string): number {
+    if (model.includes('o3-pro')) return 200_000
+    if (model.includes('o3') || model.includes('o4')) return 200_000
+    if (model.includes('gpt-4.1')) return 1_047_576
+    return 200_000
+  },
+}

--- a/src/providers/codex/parser.ts
+++ b/src/providers/codex/parser.ts
@@ -1,0 +1,233 @@
+/**
+ * Codex CLI session parser.
+ *
+ * Codex stores sessions as JSONL where each line is a RolloutLine:
+ *   { timestamp: string, item: RolloutItem }
+ *
+ * RolloutItem is a tagged union:
+ *   - SessionMeta: first line with session metadata
+ *   - ResponseItem: model response items (messages, tool calls, outputs)
+ *   - Compacted: compacted history
+ *   - EventMsg: agent events (TokenCount, ExecCommandBegin/End, etc.)
+ */
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import type { SessionRecord, AssistantRecord, UserRecord, TurnMetrics, TokenUsage, ToolCallSummary } from '../../types.js'
+import type { SessionParser, SessionContext } from '../types.js'
+
+// Codex-specific record types
+interface RolloutLine {
+  timestamp: string
+  item: Record<string, unknown>
+}
+
+function parseCodexLine(line: string): SessionRecord | null {
+  const trimmed = line.trim()
+  if (!trimmed) return null
+
+  try {
+    const rollout = JSON.parse(trimmed) as RolloutLine
+    if (!rollout.item) return null
+
+    const item = rollout.item
+
+    // SessionMeta — first line
+    if ('id' in item && 'cwd' in item && 'cli_version' in item) {
+      return {
+        type: 'user',
+        sessionId: item.id as string || '',
+        timestamp: rollout.timestamp,
+        message: { role: 'user' as const, content: '' },
+        cwd: item.cwd as string || undefined,
+        version: item.cli_version as string || undefined,
+      } as UserRecord
+    }
+
+    // Compacted — compaction boundary
+    if ('Compacted' in item || item.type === 'Compacted') {
+      return { type: 'compact_boundary' }
+    }
+
+    // EventMsg with token counts
+    if (item.type === 'EventMsg' || item.event_type === 'TokenCount') {
+      const event = (item.event || item) as Record<string, unknown>
+      if (event.type === 'TokenCount' || event.TokenCount) {
+        const tc = (event.TokenCount || event) as Record<string, unknown>
+        return {
+          type: 'assistant',
+          sessionId: '',
+          timestamp: rollout.timestamp,
+          message: {
+            role: 'assistant' as const,
+            model: (tc.model as string) || '',
+            content: [],
+            usage: {
+              input_tokens: (tc.input_tokens as number) || 0,
+              output_tokens: (tc.output_tokens as number) || 0,
+              cache_creation_input_tokens: (tc.input_tokens_cache_write as number) || 0,
+              cache_read_input_tokens: (tc.input_tokens_cache_read as number) || 0,
+            },
+          },
+        } as AssistantRecord
+      }
+    }
+
+    // ResponseItem with tool calls
+    if (item.type === 'ResponseItem') {
+      const resp = (item.response_item || item) as Record<string, unknown>
+      if (resp.type === 'function_call') {
+        return {
+          type: 'assistant',
+          sessionId: '',
+          timestamp: rollout.timestamp,
+          message: {
+            role: 'assistant' as const,
+            model: '',
+            content: [{
+              type: 'tool_use' as const,
+              name: resp.name as string || 'unknown',
+              id: resp.call_id as string || resp.id as string || '',
+              input: tryParseJson(resp.arguments as string),
+            }],
+          },
+        } as AssistantRecord
+      }
+      if (resp.type === 'message' && resp.role === 'assistant') {
+        const content = resp.content as Array<Record<string, unknown>> | undefined
+        const text = content?.map(c => c.text || '').join('') || ''
+        return {
+          type: 'assistant',
+          sessionId: '',
+          timestamp: rollout.timestamp,
+          message: {
+            role: 'assistant' as const,
+            model: '',
+            content: text ? [{ type: 'text' as const, text }] : [],
+          },
+        } as AssistantRecord
+      }
+      if (resp.type === 'message' && resp.role === 'user') {
+        const content = resp.content as Array<Record<string, unknown>> | string | undefined
+        const text = typeof content === 'string'
+          ? content
+          : Array.isArray(content)
+            ? content.map(c => c.text || '').join('')
+            : ''
+        return {
+          type: 'user',
+          sessionId: '',
+          timestamp: rollout.timestamp,
+          message: { role: 'user' as const, content: text },
+        } as UserRecord
+      }
+    }
+
+    // Generic event — keep as generic record
+    return {
+      type: 'generic',
+      sessionId: '',
+      timestamp: rollout.timestamp,
+    }
+  } catch {
+    return null
+  }
+}
+
+function tryParseJson(str: unknown): unknown {
+  if (typeof str !== 'string') return str
+  try { return JSON.parse(str) } catch { return str }
+}
+
+export const codexParser: SessionParser = {
+  parseLine: parseCodexLine,
+
+  async parseFile(filePath: string): Promise<SessionRecord[]> {
+    const content = await readFile(filePath, 'utf-8')
+    const records: SessionRecord[] = []
+    for (const line of content.split('\n')) {
+      const record = parseCodexLine(line)
+      if (record) records.push(record)
+    }
+    return records
+  },
+
+  extractTurns(records: SessionRecord[]): TurnMetrics[] {
+    const turns: TurnMetrics[] = []
+    let turnIndex = 0
+
+    for (const record of records) {
+      if (record.type !== 'assistant') continue
+      const assistant = record as AssistantRecord
+      if (!assistant.message?.usage) continue
+
+      const usage = normalizeUsage(assistant.message.usage)
+      const totalInput = usage.input_tokens + usage.cache_creation_input_tokens + usage.cache_read_input_tokens
+      const cacheRatio = totalInput > 0 ? usage.cache_read_input_tokens / totalInput : 0
+
+      const toolCalls: ToolCallSummary[] = (assistant.message.content || [])
+        .filter(block => block.type === 'tool_use')
+        .map(block => ({
+          name: block.name || 'unknown',
+          inputHash: hashValue(block.input),
+          outputHash: '',
+          inputLabel: codexParser.extractTurns.name, // placeholder
+        }))
+
+      turns.push({ turnIndex: turnIndex++, timestamp: assistant.timestamp, usage, cacheRatio, toolCalls })
+    }
+
+    return turns
+  },
+
+  extractModel(records: SessionRecord[]): string | null {
+    for (let i = records.length - 1; i >= 0; i--) {
+      const r = records[i]
+      if (r.type === 'assistant') {
+        const model = (r as AssistantRecord).message?.model
+        if (model) return model
+      }
+    }
+    return null
+  },
+
+  extractContext(records: SessionRecord[]): SessionContext {
+    let cwd: string | null = null
+    let gitBranch: string | null = null
+    let firstUserMessage: string | null = null
+
+    for (const record of records) {
+      if (record.type === 'user') {
+        const user = record as UserRecord
+        if (!cwd && user.cwd) cwd = user.cwd
+        if (!gitBranch && user.gitBranch) gitBranch = user.gitBranch
+        if (!firstUserMessage) {
+          const content = user.message?.content
+          if (typeof content === 'string' && content.trim()) {
+            firstUserMessage = content.trim()
+          }
+        }
+      }
+    }
+
+    const projectName = cwd ? cwd.split(/[/\\]/).filter(Boolean).pop() ?? null : null
+    return { cwd, gitBranch, projectName, firstUserMessage }
+  },
+
+  hasResumeBoundary(records: SessionRecord[]): boolean {
+    return records.some(r => r.type === 'compact_boundary')
+  },
+}
+
+function normalizeUsage(usage: Partial<TokenUsage>): TokenUsage {
+  return {
+    input_tokens: usage.input_tokens ?? 0,
+    output_tokens: usage.output_tokens ?? 0,
+    cache_creation_input_tokens: usage.cache_creation_input_tokens ?? 0,
+    cache_read_input_tokens: usage.cache_read_input_tokens ?? 0,
+  }
+}
+
+function hashValue(value: unknown): string {
+  const str = typeof value === 'string' ? value : JSON.stringify(value ?? '')
+  return createHash('sha256').update(str).digest('hex').slice(0, 16)
+}

--- a/src/providers/codex/pricing.ts
+++ b/src/providers/codex/pricing.ts
@@ -1,0 +1,58 @@
+import type { PricingConfig } from '../../types.js'
+import type { PricingResolver } from '../types.js'
+
+export const CODEX_MODELS: Record<string, PricingConfig> = {
+  'gpt-4.1': {
+    model: 'gpt-4.1',
+    inputPerMillion: 2.0,
+    outputPerMillion: 8.0,
+    cacheCreationPerMillion: 2.5,
+    cacheReadPerMillion: 0.5,
+  },
+  'gpt-4.1-mini': {
+    model: 'gpt-4.1-mini',
+    inputPerMillion: 0.4,
+    outputPerMillion: 1.6,
+    cacheCreationPerMillion: 0.5,
+    cacheReadPerMillion: 0.1,
+  },
+  'gpt-4.1-nano': {
+    model: 'gpt-4.1-nano',
+    inputPerMillion: 0.1,
+    outputPerMillion: 0.4,
+    cacheCreationPerMillion: 0.125,
+    cacheReadPerMillion: 0.025,
+  },
+  'o3': {
+    model: 'o3',
+    inputPerMillion: 2.0,
+    outputPerMillion: 8.0,
+    cacheCreationPerMillion: 2.5,
+    cacheReadPerMillion: 0.5,
+  },
+  'o4-mini': {
+    model: 'o4-mini',
+    inputPerMillion: 1.1,
+    outputPerMillion: 4.4,
+    cacheCreationPerMillion: 1.375,
+    cacheReadPerMillion: 0.275,
+  },
+  'o3-pro': {
+    model: 'o3-pro',
+    inputPerMillion: 20.0,
+    outputPerMillion: 80.0,
+    cacheCreationPerMillion: 25.0,
+    cacheReadPerMillion: 5.0,
+  },
+}
+
+export const codexPricing: PricingResolver = {
+  models: CODEX_MODELS,
+  defaultPricing: CODEX_MODELS['o4-mini'],
+  getPricing(modelId: string): PricingConfig {
+    for (const [key, pricing] of Object.entries(CODEX_MODELS)) {
+      if (modelId.startsWith(key)) return pricing
+    }
+    return this.defaultPricing
+  },
+}

--- a/src/providers/codex/tools.ts
+++ b/src/providers/codex/tools.ts
@@ -1,0 +1,73 @@
+import type { ToolNameMapper, CanonicalTool } from '../types.js'
+
+const TOOL_MAP: Record<string, CanonicalTool> = {
+  shell: 'bash_execute',
+  exec_command: 'bash_execute',
+  write_stdin: 'bash_execute',
+  apply_patch: 'file_edit',
+  list_dir: 'file_read',
+  view_image: 'file_read',
+  js_repl: 'bash_execute',
+  js_repl_reset: 'bash_execute',
+  plan: 'other',
+  request_permissions: 'other',
+  request_user_input: 'other',
+  tool_search: 'other',
+  tool_suggest: 'other',
+  code_mode_execute: 'bash_execute',
+  code_mode_wait: 'other',
+}
+
+const REVERSE_MAP: Record<CanonicalTool, string> = {
+  bash_execute: 'shell',
+  file_read: 'list_dir',
+  file_write: 'apply_patch',
+  file_edit: 'apply_patch',
+  file_search: 'shell',
+  web_search: 'shell',
+  web_fetch: 'shell',
+  browser: 'shell',
+  mcp_tool: 'shell',
+  other: 'shell',
+}
+
+export const codexTools: ToolNameMapper = {
+  toCanonical(providerToolName: string): CanonicalTool {
+    return TOOL_MAP[providerToolName] ?? 'other'
+  },
+
+  fromCanonical(canonical: CanonicalTool): string {
+    return REVERSE_MAP[canonical] ?? 'shell'
+  },
+
+  extractInputLabel(toolName: string, input: unknown): string {
+    if (!input || typeof input !== 'object') return ''
+    const obj = input as Record<string, unknown>
+
+    switch (toolName) {
+      case 'shell': {
+        // Codex shell takes { command: string[] }
+        const cmd = Array.isArray(obj.command)
+          ? (obj.command as string[]).join(' ')
+          : typeof obj.command === 'string' ? obj.command : ''
+        return cmd.split('\n')[0].trim().slice(0, 60)
+      }
+      case 'exec_command': {
+        const cmd = typeof obj.cmd === 'string' ? obj.cmd : ''
+        return cmd.split('\n')[0].trim().slice(0, 60)
+      }
+      case 'apply_patch': {
+        const patch = typeof obj.patch === 'string' ? obj.patch : ''
+        // Extract first file path from patch content
+        const match = patch.match(/^(?:---|\+\+\+)\s+(.+)/m)
+        return match ? match[1].split(/[/\\]/).pop() || '' : ''
+      }
+      case 'list_dir': {
+        const dir = typeof obj.path === 'string' ? obj.path : ''
+        return dir.split(/[/\\]/).pop() || dir
+      }
+      default:
+        return ''
+    }
+  },
+}

--- a/src/providers/copilot/index.ts
+++ b/src/providers/copilot/index.ts
@@ -1,0 +1,76 @@
+/**
+ * GitHub Copilot provider (Tier 3 — limited monitoring).
+ *
+ * Copilot stores sessions in VS Code's workspaceStorage SQLite.
+ * No hooks available. Subscription-based pricing (not per-token).
+ */
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import { basename } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import type { Provider, SessionParser, SessionDiscovery, PricingResolver, ToolNameMapper, CanonicalTool, SessionContext } from '../types.js'
+import type { PricingConfig, SessionRecord, TurnMetrics } from '../../types.js'
+
+// Copilot is subscription-based — these are approximate per-token costs for tracking
+const COPILOT_MODELS: Record<string, PricingConfig> = {
+  'gpt-4o': { model: 'gpt-4o', inputPerMillion: 2.5, outputPerMillion: 10.0, cacheCreationPerMillion: 3.125, cacheReadPerMillion: 1.25 },
+  'claude-sonnet': { model: 'claude-sonnet', inputPerMillion: 3.0, outputPerMillion: 15.0, cacheCreationPerMillion: 3.75, cacheReadPerMillion: 0.3 },
+  'copilot-default': { model: 'copilot-default', inputPerMillion: 0, outputPerMillion: 0, cacheCreationPerMillion: 0, cacheReadPerMillion: 0 },
+}
+
+const pricing: PricingResolver = {
+  models: COPILOT_MODELS,
+  defaultPricing: COPILOT_MODELS['copilot-default'],
+  getPricing(modelId: string): PricingConfig {
+    for (const [key, p] of Object.entries(COPILOT_MODELS)) { if (modelId.startsWith(key)) return p }
+    return this.defaultPricing
+  },
+}
+
+const tools: ToolNameMapper = {
+  toCanonical(name: string): CanonicalTool {
+    const map: Record<string, CanonicalTool> = { read_file: 'file_read', run_terminal_command: 'bash_execute', edit_file: 'file_edit', workspace_search: 'file_search', get_diagnostics: 'other' }
+    return map[name] ?? 'other'
+  },
+  fromCanonical(c: CanonicalTool): string { return c === 'bash_execute' ? 'run_terminal_command' : 'read_file' },
+  extractInputLabel(): string { return '' },
+}
+
+const parser: SessionParser = {
+  parseLine(line: string): SessionRecord | null { try { return JSON.parse(line.trim()) } catch { return null } },
+  async parseFile(filePath: string): Promise<SessionRecord[]> {
+    // Would need better-sqlite3 to read state.vscdb — return empty for now
+    return []
+  },
+  extractTurns(): TurnMetrics[] { return [] },
+  extractModel(): string | null { return null },
+  extractContext(): SessionContext { return { cwd: null, gitBranch: null, projectName: null, firstUserMessage: null } },
+  hasResumeBoundary(): boolean { return false },
+}
+
+const discovery: SessionDiscovery = {
+  fileExtensions: ['.vscdb'],
+  watchDepth: 2,
+  extractSessionId(fp: string): string { return basename(fp).replace('.vscdb', '') },
+  extractProjectPath(): string { return 'copilot' },
+}
+
+function getCopilotDataDir(): string {
+  if (process.platform === 'darwin') return resolve(homedir(), 'Library/Application Support/Code/User/workspaceStorage')
+  if (process.platform === 'win32') return resolve(process.env.APPDATA || homedir(), 'Code/User/workspaceStorage')
+  return resolve(homedir(), '.config/Code/User/workspaceStorage')
+}
+
+export const copilotProvider: Provider = {
+  name: 'copilot',
+  displayName: 'GitHub Copilot',
+  tier: 3,
+  directories: {
+    sessionsDir: getCopilotDataDir,
+    configDir: () => resolve(homedir(), '.config/github-copilot'),
+    stateDir: () => resolve(homedir(), '.clauditor'),
+  },
+  parser, discovery, pricing, tools,
+  hooks: null,
+  getContextLimit(): number { return 128_000 },
+}

--- a/src/providers/cursor/better-sqlite3.d.ts
+++ b/src/providers/cursor/better-sqlite3.d.ts
@@ -1,0 +1,20 @@
+// Type stub for optional better-sqlite3 dependency
+declare module 'better-sqlite3' {
+  interface Statement {
+    all(...params: unknown[]): unknown[]
+    get(...params: unknown[]): unknown
+    run(...params: unknown[]): unknown
+  }
+
+  interface Database {
+    prepare(sql: string): Statement
+    close(): void
+  }
+
+  interface DatabaseConstructor {
+    new (filename: string, options?: { readonly?: boolean }): Database
+  }
+
+  const Database: DatabaseConstructor
+  export default Database
+}

--- a/src/providers/cursor/discovery.ts
+++ b/src/providers/cursor/discovery.ts
@@ -1,0 +1,21 @@
+import { basename } from 'node:path'
+import type { SessionDiscovery } from '../types.js'
+
+/**
+ * Cursor stores sessions in SQLite (state.vscdb), not as individual files.
+ * Discovery here handles the case where we export sessions to JSONL for monitoring.
+ * Direct SQLite reading is handled by the parser.
+ */
+export const cursorDiscovery: SessionDiscovery = {
+  fileExtensions: ['.vscdb'],
+  watchDepth: 2,
+
+  extractSessionId(filePath: string): string {
+    return basename(filePath).replace('.vscdb', '')
+  },
+
+  extractProjectPath(filePath: string, _baseDir: string): string {
+    // Cursor uses workspace hashes — can look up workspace.json for real paths
+    return 'cursor'
+  },
+}

--- a/src/providers/cursor/hooks.ts
+++ b/src/providers/cursor/hooks.ts
@@ -1,0 +1,150 @@
+/**
+ * Cursor hook manager — installs/uninstalls clauditor hooks
+ * into ~/.cursor/hooks.json.
+ *
+ * Cursor has 6 hook events with a different format than Claude/Codex:
+ * - beforeSubmitPrompt, beforeShellExecution, beforeMCPExecution,
+ *   beforeReadFile, afterFileEdit, stop
+ * - Hook output: { continue, permission, userMessage, agentMessage }
+ */
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { homedir } from 'node:os'
+import type { HookManager, CanonicalHookEvent } from '../types.js'
+import type { HookDecision } from '../../types.js'
+
+const CURSOR_HOOKS_PATH = resolve(homedir(), '.cursor/hooks.json')
+const CLAUDITOR_MARKER = 'clauditor hook'
+
+const EVENT_MAP: Record<CanonicalHookEvent, string | null> = {
+  session_start: null, // Cursor doesn't have a session start hook
+  user_prompt_submit: 'beforeSubmitPrompt',
+  pre_tool_use: 'beforeShellExecution',
+  post_tool_use: 'afterFileEdit',
+  pre_compact: null,
+  post_compact: null,
+  stop: 'stop',
+}
+
+interface CursorHookEntry {
+  command: string
+}
+
+interface CursorHooksFile {
+  version: number
+  hooks: Record<string, CursorHookEntry[]>
+}
+
+function getHookCommand(subcommand: string): string {
+  const isNpx = process.argv[1]?.includes('_npx') || process.env.npm_execpath?.includes('npx')
+  if (isNpx) {
+    return `npx -y @iyadhk/clauditor hook ${subcommand} --provider cursor`
+  }
+  return `clauditor hook ${subcommand} --provider cursor`
+}
+
+const HOOK_COMMANDS: Record<string, string> = {
+  beforeSubmitPrompt: getHookCommand('user-prompt-submit'),
+  beforeShellExecution: getHookCommand('pre-tool-use'),
+  beforeMCPExecution: getHookCommand('pre-tool-use'),
+  afterFileEdit: getHookCommand('post-tool-use'),
+  stop: getHookCommand('stop'),
+}
+
+async function readHooksFile(): Promise<CursorHooksFile> {
+  try {
+    const content = await readFile(CURSOR_HOOKS_PATH, 'utf-8')
+    return JSON.parse(content)
+  } catch {
+    return { version: 1, hooks: {} }
+  }
+}
+
+async function writeHooksFile(data: CursorHooksFile): Promise<void> {
+  await mkdir(dirname(CURSOR_HOOKS_PATH), { recursive: true })
+  await writeFile(CURSOR_HOOKS_PATH, JSON.stringify(data, null, 2) + '\n')
+}
+
+export const cursorHooks: HookManager = {
+  supportedEvents: [
+    'user_prompt_submit',
+    'pre_tool_use',
+    'post_tool_use',
+    'stop',
+  ] as CanonicalHookEvent[],
+
+  blockExitCode: 1, // Cursor uses permission: "deny" in output, not exit codes
+
+  eventName(canonical: CanonicalHookEvent): string | null {
+    return EVENT_MAP[canonical] ?? null
+  },
+
+  async install(): Promise<string[]> {
+    const file = await readHooksFile()
+    const messages: string[] = []
+
+    for (const [eventName, command] of Object.entries(HOOK_COMMANDS)) {
+      if (!file.hooks[eventName]) {
+        file.hooks[eventName] = []
+      }
+
+      const alreadyInstalled = file.hooks[eventName].some(
+        entry => entry.command.includes(CLAUDITOR_MARKER)
+      )
+
+      if (alreadyInstalled) {
+        messages.push(`${eventName}: already installed (skipped)`)
+        continue
+      }
+
+      file.hooks[eventName].push({ command })
+      messages.push(`${eventName}: ✓ installed`)
+    }
+
+    await writeHooksFile(file)
+    messages.push(`\nHooks written to ${CURSOR_HOOKS_PATH}`)
+    return messages
+  },
+
+  async uninstall(): Promise<string[]> {
+    const file = await readHooksFile()
+    const messages: string[] = []
+
+    for (const eventName of Object.keys(file.hooks)) {
+      const before = file.hooks[eventName].length
+      file.hooks[eventName] = file.hooks[eventName].filter(
+        entry => !entry.command.includes(CLAUDITOR_MARKER)
+      )
+      const removed = before - file.hooks[eventName].length
+      if (removed > 0) {
+        messages.push(`${eventName}: ✓ removed ${removed} clauditor hook(s)`)
+      }
+      if (file.hooks[eventName].length === 0) {
+        delete file.hooks[eventName]
+      }
+    }
+
+    await writeHooksFile(file)
+    messages.push(`\nHooks written to ${CURSOR_HOOKS_PATH}`)
+    return messages
+  },
+
+  formatOutput(decision: HookDecision): string {
+    // Translate clauditor's HookDecision to Cursor's format
+    if (decision.decision === 'block') {
+      return JSON.stringify({
+        continue: false,
+        permission: 'deny',
+        agentMessage: decision.reason || 'Blocked by clauditor',
+      })
+    }
+    if (decision.additionalContext) {
+      return JSON.stringify({
+        continue: true,
+        permission: 'allow',
+        agentMessage: decision.additionalContext,
+      })
+    }
+    return JSON.stringify({ continue: true, permission: 'allow' })
+  },
+}

--- a/src/providers/cursor/index.ts
+++ b/src/providers/cursor/index.ts
@@ -1,0 +1,51 @@
+/**
+ * Cursor IDE provider.
+ *
+ * Cursor is a VS Code fork with:
+ * - SQLite session storage (state.vscdb)
+ * - 6 hook events in .cursor/hooks.json
+ * - Agent mode with terminal, file edit, search, browser tools
+ */
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import type { Provider } from '../types.js'
+import { cursorParser } from './parser.js'
+import { cursorDiscovery } from './discovery.js'
+import { cursorPricing } from './pricing.js'
+import { cursorTools } from './tools.js'
+import { cursorHooks } from './hooks.js'
+
+function getCursorDataDir(): string {
+  if (process.platform === 'darwin') {
+    return resolve(homedir(), 'Library/Application Support/Cursor')
+  }
+  if (process.platform === 'win32') {
+    return resolve(process.env.APPDATA || homedir(), 'Cursor')
+  }
+  return resolve(homedir(), '.config/Cursor')
+}
+
+export const cursorProvider: Provider = {
+  name: 'cursor',
+  displayName: 'Cursor',
+  tier: 1,
+
+  directories: {
+    sessionsDir: () => resolve(getCursorDataDir(), 'User/globalStorage'),
+    configDir: () => resolve(homedir(), '.cursor'),
+    stateDir: () => resolve(homedir(), '.clauditor'),
+  },
+
+  parser: cursorParser,
+  discovery: cursorDiscovery,
+  pricing: cursorPricing,
+  tools: cursorTools,
+  hooks: cursorHooks,
+
+  getContextLimit(model: string): number {
+    if (model.includes('gpt-4o')) return 128_000
+    if (model.includes('claude') && model.includes('opus')) return 1_000_000
+    if (model.includes('claude')) return 200_000
+    return 128_000
+  },
+}

--- a/src/providers/cursor/parser.ts
+++ b/src/providers/cursor/parser.ts
@@ -1,0 +1,160 @@
+/**
+ * Cursor session parser.
+ *
+ * Cursor stores conversations in SQLite (state.vscdb) with:
+ * - composerData:<id> → session metadata
+ * - bubbleId:<composerId>:<bubbleId> → individual messages
+ *
+ * For now, this parser handles exported JSONL or direct SQLite reading
+ * via optional better-sqlite3 dependency.
+ */
+import { readFile } from 'node:fs/promises'
+import type { SessionRecord, AssistantRecord, UserRecord, TurnMetrics, TokenUsage, ToolCallSummary } from '../../types.js'
+import type { SessionParser, SessionContext } from '../types.js'
+
+/**
+ * Try to read Cursor's state.vscdb SQLite database.
+ * Returns null if better-sqlite3 is not available.
+ */
+async function tryReadSqlite(filePath: string): Promise<SessionRecord[] | null> {
+  try {
+    // Dynamic import — better-sqlite3 is optional
+    const Database = (await import('better-sqlite3')).default
+    const db = new Database(filePath, { readonly: true })
+
+    const records: SessionRecord[] = []
+    const rows = db.prepare(
+      `SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%' ORDER BY key`
+    ).all() as Array<{ key: string; value: string }>
+
+    for (const row of rows) {
+      try {
+        const data = JSON.parse(row.value)
+        if (!data.composerId) continue
+
+        // Create a session marker
+        records.push({
+          type: 'user',
+          sessionId: data.composerId,
+          timestamp: new Date(data.createdAt || 0).toISOString(),
+          message: { role: 'user', content: '' },
+        } as UserRecord)
+
+        // Extract usage data if available
+        if (data.usageData) {
+          for (const [model, usage] of Object.entries(data.usageData)) {
+            const u = usage as Record<string, unknown>
+            records.push({
+              type: 'assistant',
+              sessionId: data.composerId,
+              timestamp: new Date(data.lastUpdatedAt || 0).toISOString(),
+              message: {
+                role: 'assistant',
+                model,
+                content: [],
+                usage: {
+                  input_tokens: (u.inputTokens as number) || 0,
+                  output_tokens: (u.outputTokens as number) || 0,
+                  cache_creation_input_tokens: 0,
+                  cache_read_input_tokens: 0,
+                },
+              },
+            } as AssistantRecord)
+          }
+        }
+      } catch {
+        continue
+      }
+    }
+
+    db.close()
+    return records
+  } catch {
+    // better-sqlite3 not available or file not accessible
+    return null
+  }
+}
+
+export const cursorParser: SessionParser = {
+  parseLine(line: string): SessionRecord | null {
+    const trimmed = line.trim()
+    if (!trimmed) return null
+    try {
+      return JSON.parse(trimmed)
+    } catch {
+      return null
+    }
+  },
+
+  async parseFile(filePath: string): Promise<SessionRecord[]> {
+    // Try SQLite first for .vscdb files
+    if (filePath.endsWith('.vscdb')) {
+      const records = await tryReadSqlite(filePath)
+      if (records) return records
+    }
+
+    // Fall back to JSONL
+    const content = await readFile(filePath, 'utf-8')
+    const records: SessionRecord[] = []
+    for (const line of content.split('\n')) {
+      const record = cursorParser.parseLine(line)
+      if (record) records.push(record)
+    }
+    return records
+  },
+
+  extractTurns(records: SessionRecord[]): TurnMetrics[] {
+    const turns: TurnMetrics[] = []
+    let turnIndex = 0
+
+    for (const record of records) {
+      if (record.type !== 'assistant') continue
+      const assistant = record as AssistantRecord
+      if (!assistant.message?.usage) continue
+
+      const usage = normalizeUsage(assistant.message.usage)
+      const totalInput = usage.input_tokens + usage.cache_creation_input_tokens + usage.cache_read_input_tokens
+      const cacheRatio = totalInput > 0 ? usage.cache_read_input_tokens / totalInput : 0
+
+      const toolCalls: ToolCallSummary[] = (assistant.message.content || [])
+        .filter(block => block.type === 'tool_use')
+        .map(block => ({
+          name: block.name || 'unknown',
+          inputHash: '',
+          outputHash: '',
+        }))
+
+      turns.push({ turnIndex: turnIndex++, timestamp: assistant.timestamp, usage, cacheRatio, toolCalls })
+    }
+
+    return turns
+  },
+
+  extractModel(records: SessionRecord[]): string | null {
+    for (let i = records.length - 1; i >= 0; i--) {
+      const r = records[i]
+      if (r.type === 'assistant') {
+        const model = (r as AssistantRecord).message?.model
+        if (model) return model
+      }
+    }
+    return null
+  },
+
+  extractContext(records: SessionRecord[]): SessionContext {
+    return { cwd: null, gitBranch: null, projectName: null, firstUserMessage: null }
+  },
+
+  hasResumeBoundary(records: SessionRecord[]): boolean {
+    return records.some(r => r.type === 'compact_boundary')
+  },
+}
+
+function normalizeUsage(usage: Partial<TokenUsage>): TokenUsage {
+  return {
+    input_tokens: usage.input_tokens ?? 0,
+    output_tokens: usage.output_tokens ?? 0,
+    cache_creation_input_tokens: usage.cache_creation_input_tokens ?? 0,
+    cache_read_input_tokens: usage.cache_read_input_tokens ?? 0,
+  }
+}

--- a/src/providers/cursor/pricing.ts
+++ b/src/providers/cursor/pricing.ts
@@ -1,0 +1,49 @@
+import type { PricingConfig } from '../../types.js'
+import type { PricingResolver } from '../types.js'
+
+/**
+ * Cursor pricing — Cursor uses various models. These are the common ones
+ * available through Cursor's model picker. Pricing is approximate based
+ * on publicly available model pricing.
+ */
+export const CURSOR_MODELS: Record<string, PricingConfig> = {
+  'gpt-4o': {
+    model: 'gpt-4o',
+    inputPerMillion: 2.5,
+    outputPerMillion: 10.0,
+    cacheCreationPerMillion: 3.125,
+    cacheReadPerMillion: 1.25,
+  },
+  'gpt-4o-mini': {
+    model: 'gpt-4o-mini',
+    inputPerMillion: 0.15,
+    outputPerMillion: 0.6,
+    cacheCreationPerMillion: 0.1875,
+    cacheReadPerMillion: 0.075,
+  },
+  'claude-sonnet-4-6': {
+    model: 'claude-sonnet-4-6',
+    inputPerMillion: 3.0,
+    outputPerMillion: 15.0,
+    cacheCreationPerMillion: 3.75,
+    cacheReadPerMillion: 0.3,
+  },
+  'cursor-small': {
+    model: 'cursor-small',
+    inputPerMillion: 0.5,
+    outputPerMillion: 1.5,
+    cacheCreationPerMillion: 0.625,
+    cacheReadPerMillion: 0.125,
+  },
+}
+
+export const cursorPricing: PricingResolver = {
+  models: CURSOR_MODELS,
+  defaultPricing: CURSOR_MODELS['gpt-4o'],
+  getPricing(modelId: string): PricingConfig {
+    for (const [key, pricing] of Object.entries(CURSOR_MODELS)) {
+      if (modelId.startsWith(key)) return pricing
+    }
+    return this.defaultPricing
+  },
+}

--- a/src/providers/cursor/tools.ts
+++ b/src/providers/cursor/tools.ts
@@ -1,0 +1,63 @@
+import type { ToolNameMapper, CanonicalTool } from '../types.js'
+
+const TOOL_MAP: Record<string, CanonicalTool> = {
+  run_terminal_command: 'bash_execute',
+  shell_execution: 'bash_execute',
+  read_file: 'file_read',
+  edit_file: 'file_edit',
+  file_edit: 'file_edit',
+  delete_file: 'file_write',
+  codebase_search: 'file_search',
+  file_search: 'file_search',
+  grep_search: 'file_search',
+  list_directory: 'file_read',
+  web_search: 'web_search',
+  browser_action: 'browser',
+  mcp_tool: 'mcp_tool',
+}
+
+const REVERSE_MAP: Record<CanonicalTool, string> = {
+  bash_execute: 'run_terminal_command',
+  file_read: 'read_file',
+  file_write: 'edit_file',
+  file_edit: 'edit_file',
+  file_search: 'codebase_search',
+  web_search: 'web_search',
+  web_fetch: 'web_search',
+  browser: 'browser_action',
+  mcp_tool: 'mcp_tool',
+  other: 'run_terminal_command',
+}
+
+export const cursorTools: ToolNameMapper = {
+  toCanonical(providerToolName: string): CanonicalTool {
+    return TOOL_MAP[providerToolName] ?? 'other'
+  },
+
+  fromCanonical(canonical: CanonicalTool): string {
+    return REVERSE_MAP[canonical] ?? 'run_terminal_command'
+  },
+
+  extractInputLabel(toolName: string, input: unknown): string {
+    if (!input || typeof input !== 'object') return ''
+    const obj = input as Record<string, unknown>
+
+    switch (toolName) {
+      case 'run_terminal_command':
+      case 'shell_execution': {
+        const cmd = typeof obj.command === 'string' ? obj.command : ''
+        return cmd.split('\n')[0].trim().slice(0, 60)
+      }
+      case 'read_file':
+      case 'edit_file':
+      case 'file_edit': {
+        const fp = typeof obj.file_path === 'string'
+          ? obj.file_path
+          : typeof obj.path === 'string' ? obj.path : ''
+        return fp.split(/[/\\]/).pop() || ''
+      }
+      default:
+        return ''
+    }
+  },
+}

--- a/src/providers/gemini/index.ts
+++ b/src/providers/gemini/index.ts
@@ -1,0 +1,139 @@
+/**
+ * Gemini CLI provider (Tier 2 — session monitoring only, no hooks).
+ */
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import { basename } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import type { Provider, SessionParser, SessionDiscovery, PricingResolver, ToolNameMapper, CanonicalTool, SessionContext } from '../types.js'
+import type { PricingConfig, SessionRecord, AssistantRecord, UserRecord, TurnMetrics, TokenUsage, ToolCallSummary, ContentBlock } from '../../types.js'
+
+// Pricing
+const GEMINI_MODELS: Record<string, PricingConfig> = {
+  'gemini-2.5-pro': { model: 'gemini-2.5-pro', inputPerMillion: 1.25, outputPerMillion: 10.0, cacheCreationPerMillion: 1.5625, cacheReadPerMillion: 0.3125 },
+  'gemini-2.5-flash': { model: 'gemini-2.5-flash', inputPerMillion: 0.15, outputPerMillion: 0.6, cacheCreationPerMillion: 0.1875, cacheReadPerMillion: 0.0375 },
+  'gemini-2.0-flash': { model: 'gemini-2.0-flash', inputPerMillion: 0.1, outputPerMillion: 0.4, cacheCreationPerMillion: 0.125, cacheReadPerMillion: 0.025 },
+}
+
+const pricing: PricingResolver = {
+  models: GEMINI_MODELS,
+  defaultPricing: GEMINI_MODELS['gemini-2.5-flash'],
+  getPricing(modelId: string): PricingConfig {
+    for (const [key, p] of Object.entries(GEMINI_MODELS)) {
+      if (modelId.startsWith(key)) return p
+    }
+    return this.defaultPricing
+  },
+}
+
+// Tools
+const TOOL_MAP: Record<string, CanonicalTool> = {
+  ReadFile: 'file_read', ReadManyFiles: 'file_read', WriteFile: 'file_write',
+  EditFile: 'file_edit', ListDirectory: 'file_read', SearchFiles: 'file_search',
+  ExecuteCommand: 'bash_execute', WebSearch: 'web_search', WebFetch: 'web_fetch',
+  GlobTool: 'file_search', GrepTool: 'file_search',
+}
+
+const tools: ToolNameMapper = {
+  toCanonical(name: string): CanonicalTool { return TOOL_MAP[name] ?? 'other' },
+  fromCanonical(c: CanonicalTool): string {
+    const rev: Record<CanonicalTool, string> = { bash_execute: 'ExecuteCommand', file_read: 'ReadFile', file_write: 'WriteFile', file_edit: 'EditFile', file_search: 'SearchFiles', web_search: 'WebSearch', web_fetch: 'WebFetch', browser: 'WebFetch', mcp_tool: 'ExecuteCommand', other: 'ExecuteCommand' }
+    return rev[c] ?? 'ExecuteCommand'
+  },
+  extractInputLabel(toolName: string, input: unknown): string {
+    if (!input || typeof input !== 'object') return ''
+    const obj = input as Record<string, unknown>
+    if (toolName === 'ExecuteCommand') return (typeof obj.command === 'string' ? obj.command : '').split('\n')[0].slice(0, 60)
+    if (['ReadFile', 'WriteFile', 'EditFile'].includes(toolName)) return (typeof obj.path === 'string' ? obj.path : '').split(/[/\\]/).pop() || ''
+    return ''
+  },
+}
+
+// Parser
+const parser: SessionParser = {
+  parseLine(line: string): SessionRecord | null {
+    try { return JSON.parse(line.trim()) } catch { return null }
+  },
+
+  async parseFile(filePath: string): Promise<SessionRecord[]> {
+    const content = await readFile(filePath, 'utf-8')
+    const records: SessionRecord[] = []
+    try {
+      const session = JSON.parse(content)
+      const messages = session.messages || session.history || (Array.isArray(session) ? session : [])
+      for (const msg of messages) {
+        const ts = msg.timestamp || msg.createTime || new Date().toISOString()
+        if (msg.role === 'user') {
+          const text = typeof msg.parts?.[0]?.text === 'string' ? msg.parts[0].text : typeof msg.content === 'string' ? msg.content : ''
+          records.push({ type: 'user', sessionId: '', timestamp: ts, message: { role: 'user', content: text } } as UserRecord)
+        } else if (msg.role === 'model' || msg.role === 'assistant') {
+          const blocks: ContentBlock[] = []
+          if (msg.parts) {
+            for (const part of msg.parts) {
+              if (part.text) blocks.push({ type: 'text', text: part.text })
+              if (part.functionCall) blocks.push({ type: 'tool_use', name: part.functionCall.name, input: part.functionCall.args })
+            }
+          }
+          const usage = msg.usageMetadata ? {
+            input_tokens: msg.usageMetadata.promptTokenCount || 0,
+            output_tokens: msg.usageMetadata.candidatesTokenCount || 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: msg.usageMetadata.cachedContentTokenCount || 0,
+          } : undefined
+          records.push({ type: 'assistant', sessionId: '', timestamp: ts, message: { role: 'assistant', model: msg.modelVersion || '', content: blocks, usage } } as AssistantRecord)
+        }
+      }
+    } catch {
+      for (const line of content.split('\n')) {
+        const r = parser.parseLine(line)
+        if (r) records.push(r)
+      }
+    }
+    return records
+  },
+
+  extractTurns(records: SessionRecord[]): TurnMetrics[] {
+    const turns: TurnMetrics[] = []
+    let idx = 0
+    for (const r of records) {
+      if (r.type !== 'assistant') continue
+      const a = r as AssistantRecord
+      if (!a.message?.usage) continue
+      const u = a.message.usage
+      const total = u.input_tokens + u.cache_creation_input_tokens + u.cache_read_input_tokens
+      turns.push({ turnIndex: idx++, timestamp: a.timestamp, usage: u, cacheRatio: total > 0 ? u.cache_read_input_tokens / total : 0, toolCalls: (a.message.content || []).filter(b => b.type === 'tool_use').map(b => ({ name: b.name || 'unknown', inputHash: '', outputHash: '' })) })
+    }
+    return turns
+  },
+  extractModel(records: SessionRecord[]): string | null {
+    for (let i = records.length - 1; i >= 0; i--) { if (records[i].type === 'assistant') { const m = (records[i] as AssistantRecord).message?.model; if (m) return m } }
+    return null
+  },
+  extractContext(records: SessionRecord[]): SessionContext { return { cwd: null, gitBranch: null, projectName: null, firstUserMessage: null } },
+  hasResumeBoundary(): boolean { return false },
+}
+
+// Discovery
+const discovery: SessionDiscovery = {
+  fileExtensions: ['.json'],
+  watchDepth: 2,
+  extractSessionId(fp: string): string { return basename(fp).replace('.json', '') },
+  extractProjectPath(): string { return 'gemini' },
+}
+
+export const geminiProvider: Provider = {
+  name: 'gemini',
+  displayName: 'Gemini CLI',
+  tier: 2,
+  directories: {
+    sessionsDir: () => resolve(homedir(), '.gemini/history'),
+    configDir: () => resolve(homedir(), '.gemini'),
+    stateDir: () => resolve(homedir(), '.clauditor'),
+  },
+  parser, discovery, pricing, tools,
+  hooks: null,
+  getContextLimit(model: string): number {
+    if (model.includes('pro')) return 1_000_000
+    return 1_000_000 // Gemini models generally have large contexts
+  },
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Provider system entry point.
+ *
+ * Registers all known providers and exports the registry for use
+ * throughout clauditor.
+ */
+
+export { registry } from './registry.js'
+export type {
+  Provider,
+  DirectoryResolver,
+  SessionParser,
+  SessionDiscovery,
+  PricingResolver,
+  ToolNameMapper,
+  HookManager,
+  CanonicalTool,
+  CanonicalHookEvent,
+  ProviderTier,
+  SessionContext,
+} from './types.js'
+
+// Register all built-in providers
+import { registry } from './registry.js'
+import { claudeProvider } from './claude/index.js'
+import { codexProvider } from './codex/index.js'
+import { cursorProvider } from './cursor/index.js'
+import { windsurfProvider } from './windsurf/index.js'
+import { clineProvider } from './cline/index.js'
+import { geminiProvider } from './gemini/index.js'
+import { aiderProvider } from './aider/index.js'
+import { copilotProvider } from './copilot/index.js'
+import { zedProvider } from './zed/index.js'
+import { amazonqProvider } from './amazonq/index.js'
+
+// Tier 1 — full hooks + session monitoring
+registry.register(claudeProvider)
+registry.register(codexProvider)
+registry.register(cursorProvider)
+registry.register(windsurfProvider)
+registry.register(clineProvider)
+
+// Tier 2 — session monitoring only
+registry.register(geminiProvider)
+registry.register(aiderProvider)
+
+// Tier 3 — limited monitoring
+registry.register(copilotProvider)
+registry.register(zedProvider)
+registry.register(amazonqProvider)

--- a/src/providers/providers.test.ts
+++ b/src/providers/providers.test.ts
@@ -1,0 +1,1156 @@
+/**
+ * Comprehensive provider tests — verifies all 10 providers implement
+ * the Provider interface correctly, with working tool mappings, pricing,
+ * parsers, hooks, and discovery.
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+import { ProviderRegistry } from './registry.js'
+import { claudeProvider } from './claude/index.js'
+import { codexProvider } from './codex/index.js'
+import { cursorProvider } from './cursor/index.js'
+import { windsurfProvider } from './windsurf/index.js'
+import { clineProvider } from './cline/index.js'
+import { geminiProvider } from './gemini/index.js'
+import { aiderProvider } from './aider/index.js'
+import { copilotProvider } from './copilot/index.js'
+import { zedProvider } from './zed/index.js'
+import { amazonqProvider } from './amazonq/index.js'
+import type { HookDecision } from '../types.js'
+
+// ---------------------------------------------------------------------------
+// Build a fresh registry for testing (avoid import-time side effects)
+// ---------------------------------------------------------------------------
+
+let registry: ProviderRegistry
+
+const ALL_PROVIDERS = [
+  claudeProvider,
+  codexProvider,
+  cursorProvider,
+  windsurfProvider,
+  clineProvider,
+  geminiProvider,
+  aiderProvider,
+  copilotProvider,
+  zedProvider,
+  amazonqProvider,
+]
+
+const ALL_NAMES = [
+  'claude', 'codex', 'cursor', 'windsurf', 'cline',
+  'gemini', 'aider', 'copilot', 'zed', 'amazonq',
+]
+
+const TIER_1_PROVIDERS = ALL_PROVIDERS.filter((p) => p.tier === 1)
+const TIER_2_PROVIDERS = ALL_PROVIDERS.filter((p) => p.tier === 2)
+const TIER_3_PROVIDERS = ALL_PROVIDERS.filter((p) => p.tier === 3)
+
+beforeAll(() => {
+  registry = new ProviderRegistry()
+  for (const p of ALL_PROVIDERS) {
+    registry.register(p)
+  }
+})
+
+// ===========================================================================
+// 1. Registry tests
+// ===========================================================================
+
+describe('ProviderRegistry', () => {
+  it('has all 10 providers registered', () => {
+    expect(registry.getAll()).toHaveLength(10)
+  })
+
+  it('names() returns all provider identifiers', () => {
+    const names = registry.names()
+    for (const name of ALL_NAMES) {
+      expect(names).toContain(name)
+    }
+  })
+
+  it('get() returns the correct provider by name', () => {
+    for (const name of ALL_NAMES) {
+      const p = registry.get(name)
+      expect(p.name).toBe(name)
+    }
+  })
+
+  it('get() throws for unknown provider', () => {
+    expect(() => registry.get('nonexistent')).toThrow(/Unknown provider/)
+  })
+
+  it('find() returns provider or null', () => {
+    expect(registry.find('claude')).not.toBeNull()
+    expect(registry.find('nonexistent')).toBeNull()
+  })
+
+  it('detect() returns an array (may be empty if tools not installed)', () => {
+    const detected = registry.detect()
+    expect(Array.isArray(detected)).toBe(true)
+  })
+
+  it('forSessionFile() matches Claude session path', () => {
+    const homeDir = require('node:os').homedir()
+    const fakePath = `${homeDir}/.claude/projects/myproject/session-abc.jsonl`
+    const found = registry.forSessionFile(fakePath)
+    // Should match claude if the path prefix matches
+    if (found) {
+      expect(found.name).toBe('claude')
+    }
+  })
+})
+
+// ===========================================================================
+// 2. Interface compliance — every provider has the required shape
+// ===========================================================================
+
+describe('Interface compliance', () => {
+  for (const provider of ALL_PROVIDERS) {
+    describe(provider.displayName, () => {
+      it('has name and displayName as non-empty strings', () => {
+        expect(typeof provider.name).toBe('string')
+        expect(provider.name.length).toBeGreaterThan(0)
+        expect(typeof provider.displayName).toBe('string')
+        expect(provider.displayName.length).toBeGreaterThan(0)
+      })
+
+      it('has a valid tier (1, 2, or 3)', () => {
+        expect([1, 2, 3]).toContain(provider.tier)
+      })
+
+      it('has directories with sessionsDir, configDir, stateDir', () => {
+        expect(typeof provider.directories.sessionsDir).toBe('function')
+        expect(typeof provider.directories.configDir).toBe('function')
+        expect(typeof provider.directories.stateDir).toBe('function')
+        // Each returns a non-empty string path
+        expect(provider.directories.sessionsDir().length).toBeGreaterThan(0)
+        expect(provider.directories.configDir().length).toBeGreaterThan(0)
+        expect(provider.directories.stateDir()).toContain('.clauditor')
+      })
+
+      it('has a parser with all required methods', () => {
+        expect(typeof provider.parser.parseLine).toBe('function')
+        expect(typeof provider.parser.parseFile).toBe('function')
+        expect(typeof provider.parser.extractTurns).toBe('function')
+        expect(typeof provider.parser.extractModel).toBe('function')
+        expect(typeof provider.parser.extractContext).toBe('function')
+        expect(typeof provider.parser.hasResumeBoundary).toBe('function')
+      })
+
+      it('has discovery with fileExtensions, watchDepth, extractSessionId, extractProjectPath', () => {
+        expect(Array.isArray(provider.discovery.fileExtensions)).toBe(true)
+        expect(provider.discovery.fileExtensions.length).toBeGreaterThan(0)
+        expect(typeof provider.discovery.watchDepth).toBe('number')
+        expect(typeof provider.discovery.extractSessionId).toBe('function')
+        expect(typeof provider.discovery.extractProjectPath).toBe('function')
+      })
+
+      it('has pricing with models, defaultPricing, getPricing', () => {
+        expect(typeof provider.pricing.models).toBe('object')
+        expect(provider.pricing.defaultPricing).toBeDefined()
+        expect(typeof provider.pricing.defaultPricing.model).toBe('string')
+        expect(typeof provider.pricing.getPricing).toBe('function')
+      })
+
+      it('has tools with toCanonical, fromCanonical, extractInputLabel', () => {
+        expect(typeof provider.tools.toCanonical).toBe('function')
+        expect(typeof provider.tools.fromCanonical).toBe('function')
+        expect(typeof provider.tools.extractInputLabel).toBe('function')
+      })
+
+      it('has hooks (Tier 1) or null (Tier 2/3)', () => {
+        if (provider.tier === 1) {
+          expect(provider.hooks).not.toBeNull()
+          expect(Array.isArray(provider.hooks!.supportedEvents)).toBe(true)
+          expect(typeof provider.hooks!.blockExitCode).toBe('number')
+          expect(typeof provider.hooks!.eventName).toBe('function')
+          expect(typeof provider.hooks!.formatOutput).toBe('function')
+          expect(typeof provider.hooks!.install).toBe('function')
+          expect(typeof provider.hooks!.uninstall).toBe('function')
+        } else {
+          expect(provider.hooks).toBeNull()
+        }
+      })
+
+      it('has getContextLimit as a function returning a positive number', () => {
+        expect(typeof provider.getContextLimit).toBe('function')
+        expect(provider.getContextLimit('test-model')).toBeGreaterThan(0)
+      })
+    })
+  }
+})
+
+// ===========================================================================
+// 3. Tool name mapping round-trips (Tier 1 providers)
+// ===========================================================================
+
+describe('Tool name mapping round-trips', () => {
+  describe('Claude Code', () => {
+    it('maps Bash -> bash_execute -> Bash', () => {
+      expect(claudeProvider.tools.toCanonical('Bash')).toBe('bash_execute')
+      expect(claudeProvider.tools.fromCanonical('bash_execute')).toBe('Bash')
+    })
+    it('maps Read -> file_read -> Read', () => {
+      expect(claudeProvider.tools.toCanonical('Read')).toBe('file_read')
+      expect(claudeProvider.tools.fromCanonical('file_read')).toBe('Read')
+    })
+    it('maps Edit -> file_edit -> Edit', () => {
+      expect(claudeProvider.tools.toCanonical('Edit')).toBe('file_edit')
+      expect(claudeProvider.tools.fromCanonical('file_edit')).toBe('Edit')
+    })
+    it('maps Write -> file_write -> Write', () => {
+      expect(claudeProvider.tools.toCanonical('Write')).toBe('file_write')
+      expect(claudeProvider.tools.fromCanonical('file_write')).toBe('Write')
+    })
+    it('maps unknown tool to other', () => {
+      expect(claudeProvider.tools.toCanonical('NonexistentTool')).toBe('other')
+    })
+    it('extractInputLabel for Bash extracts command', () => {
+      expect(claudeProvider.tools.extractInputLabel('Bash', { command: 'npm test' })).toBe('npm test')
+    })
+    it('extractInputLabel for Read extracts filename', () => {
+      expect(claudeProvider.tools.extractInputLabel('Read', { file_path: '/foo/bar/baz.ts' })).toBe('baz.ts')
+    })
+  })
+
+  describe('Codex CLI', () => {
+    it('maps shell -> bash_execute -> shell', () => {
+      expect(codexProvider.tools.toCanonical('shell')).toBe('bash_execute')
+      expect(codexProvider.tools.fromCanonical('bash_execute')).toBe('shell')
+    })
+    it('maps list_dir -> file_read -> list_dir', () => {
+      expect(codexProvider.tools.toCanonical('list_dir')).toBe('file_read')
+      expect(codexProvider.tools.fromCanonical('file_read')).toBe('list_dir')
+    })
+    it('maps apply_patch -> file_edit -> apply_patch', () => {
+      expect(codexProvider.tools.toCanonical('apply_patch')).toBe('file_edit')
+      expect(codexProvider.tools.fromCanonical('file_edit')).toBe('apply_patch')
+    })
+    it('extractInputLabel for shell with array command', () => {
+      expect(codexProvider.tools.extractInputLabel('shell', { command: ['npm', 'test'] })).toBe('npm test')
+    })
+  })
+
+  describe('Cursor', () => {
+    it('maps run_terminal_command -> bash_execute -> run_terminal_command', () => {
+      expect(cursorProvider.tools.toCanonical('run_terminal_command')).toBe('bash_execute')
+      expect(cursorProvider.tools.fromCanonical('bash_execute')).toBe('run_terminal_command')
+    })
+    it('maps read_file -> file_read -> read_file', () => {
+      expect(cursorProvider.tools.toCanonical('read_file')).toBe('file_read')
+      expect(cursorProvider.tools.fromCanonical('file_read')).toBe('read_file')
+    })
+    it('maps edit_file -> file_edit -> edit_file', () => {
+      expect(cursorProvider.tools.toCanonical('edit_file')).toBe('file_edit')
+      expect(cursorProvider.tools.fromCanonical('file_edit')).toBe('edit_file')
+    })
+  })
+
+  describe('Windsurf', () => {
+    it('maps run_command -> bash_execute -> run_command', () => {
+      expect(windsurfProvider.tools.toCanonical('run_command')).toBe('bash_execute')
+      expect(windsurfProvider.tools.fromCanonical('bash_execute')).toBe('run_command')
+    })
+    it('maps view_file -> file_read -> view_file', () => {
+      expect(windsurfProvider.tools.toCanonical('view_file')).toBe('file_read')
+      expect(windsurfProvider.tools.fromCanonical('file_read')).toBe('view_file')
+    })
+    it('maps edit_file -> file_edit -> edit_file', () => {
+      expect(windsurfProvider.tools.toCanonical('edit_file')).toBe('file_edit')
+      expect(windsurfProvider.tools.fromCanonical('file_edit')).toBe('edit_file')
+    })
+  })
+
+  describe('Cline', () => {
+    it('maps execute_command -> bash_execute -> execute_command', () => {
+      expect(clineProvider.tools.toCanonical('execute_command')).toBe('bash_execute')
+      expect(clineProvider.tools.fromCanonical('bash_execute')).toBe('execute_command')
+    })
+    it('maps read_file -> file_read -> read_file', () => {
+      expect(clineProvider.tools.toCanonical('read_file')).toBe('file_read')
+      expect(clineProvider.tools.fromCanonical('file_read')).toBe('read_file')
+    })
+    it('maps replace_in_file -> file_edit -> replace_in_file', () => {
+      expect(clineProvider.tools.toCanonical('replace_in_file')).toBe('file_edit')
+      expect(clineProvider.tools.fromCanonical('file_edit')).toBe('replace_in_file')
+    })
+    it('maps browser_action -> browser -> browser_action', () => {
+      expect(clineProvider.tools.toCanonical('browser_action')).toBe('browser')
+      expect(clineProvider.tools.fromCanonical('browser')).toBe('browser_action')
+    })
+  })
+
+  describe('Tier 2/3 providers basic tool mapping', () => {
+    it('Gemini: ExecuteCommand -> bash_execute', () => {
+      expect(geminiProvider.tools.toCanonical('ExecuteCommand')).toBe('bash_execute')
+      expect(geminiProvider.tools.fromCanonical('bash_execute')).toBe('ExecuteCommand')
+    })
+    it('Aider: /run -> bash_execute', () => {
+      expect(aiderProvider.tools.toCanonical('/run')).toBe('bash_execute')
+      expect(aiderProvider.tools.fromCanonical('bash_execute')).toBe('/run')
+    })
+    it('Copilot: run_terminal_command -> bash_execute', () => {
+      expect(copilotProvider.tools.toCanonical('run_terminal_command')).toBe('bash_execute')
+    })
+    it('Zed: run_terminal_command -> bash_execute', () => {
+      expect(zedProvider.tools.toCanonical('run_terminal_command')).toBe('bash_execute')
+    })
+    it('Amazon Q: execute_bash -> bash_execute', () => {
+      expect(amazonqProvider.tools.toCanonical('execute_bash')).toBe('bash_execute')
+      expect(amazonqProvider.tools.fromCanonical('bash_execute')).toBe('execute_bash')
+    })
+  })
+})
+
+// ===========================================================================
+// 4. Pricing lookups
+// ===========================================================================
+
+describe('Pricing lookups', () => {
+  describe('Claude', () => {
+    it('returns Sonnet pricing for claude-sonnet-4-6 prefix', () => {
+      const p = claudeProvider.pricing.getPricing('claude-sonnet-4-6-20260301')
+      expect(p.inputPerMillion).toBe(3.0)
+      expect(p.outputPerMillion).toBe(15.0)
+    })
+    it('returns Opus pricing for claude-opus-4-6', () => {
+      const p = claudeProvider.pricing.getPricing('claude-opus-4-6-20260401')
+      expect(p.inputPerMillion).toBe(15.0)
+    })
+    it('returns Haiku pricing for claude-haiku-4-5', () => {
+      const p = claudeProvider.pricing.getPricing('claude-haiku-4-5-20250101')
+      expect(p.inputPerMillion).toBe(0.8)
+    })
+    it('falls back to Sonnet (default) for unknown model', () => {
+      const p = claudeProvider.pricing.getPricing('some-unknown-model-xyz')
+      expect(p.model).toBe('claude-sonnet-4-6')
+    })
+  })
+
+  describe('Codex', () => {
+    it('returns gpt-4.1 pricing', () => {
+      const p = codexProvider.pricing.getPricing('gpt-4.1-2025-04')
+      expect(p.inputPerMillion).toBe(2.0)
+    })
+    it('returns o4-mini pricing', () => {
+      const p = codexProvider.pricing.getPricing('o4-mini-high')
+      expect(p.inputPerMillion).toBe(1.1)
+    })
+    it('falls back to o4-mini (default) for unknown', () => {
+      const p = codexProvider.pricing.getPricing('unknown-model')
+      expect(p.model).toBe('o4-mini')
+    })
+  })
+
+  describe('Cursor', () => {
+    it('returns gpt-4o pricing', () => {
+      const p = cursorProvider.pricing.getPricing('gpt-4o-2025')
+      expect(p.inputPerMillion).toBe(2.5)
+    })
+    it('returns claude-sonnet-4-6 pricing', () => {
+      const p = cursorProvider.pricing.getPricing('claude-sonnet-4-6-latest')
+      expect(p.inputPerMillion).toBe(3.0)
+    })
+    it('falls back to gpt-4o (default) for unknown', () => {
+      const p = cursorProvider.pricing.getPricing('unknown-model')
+      expect(p.model).toBe('gpt-4o')
+    })
+  })
+
+  describe('Windsurf', () => {
+    it('returns gemini-2.5-pro pricing', () => {
+      const p = windsurfProvider.pricing.getPricing('gemini-2.5-pro-latest')
+      expect(p.inputPerMillion).toBe(1.25)
+    })
+    it('falls back to windsurf-default for unknown', () => {
+      const p = windsurfProvider.pricing.getPricing('unknown-model')
+      expect(p.model).toBe('windsurf-default')
+    })
+  })
+
+  describe('Cline', () => {
+    it('returns deepseek-chat pricing', () => {
+      const p = clineProvider.pricing.getPricing('deepseek-chat-v3')
+      expect(p.inputPerMillion).toBe(0.27)
+    })
+    it('returns gemini-2.5-pro pricing', () => {
+      const p = clineProvider.pricing.getPricing('gemini-2.5-pro-exp')
+      expect(p.inputPerMillion).toBe(1.25)
+    })
+    it('falls back to claude-sonnet-4-6 for unknown', () => {
+      const p = clineProvider.pricing.getPricing('unknown')
+      expect(p.model).toBe('claude-sonnet-4-6')
+    })
+  })
+
+  describe('Gemini', () => {
+    it('returns gemini-2.5-pro pricing', () => {
+      const p = geminiProvider.pricing.getPricing('gemini-2.5-pro')
+      expect(p.inputPerMillion).toBe(1.25)
+    })
+    it('returns gemini-2.5-flash pricing', () => {
+      const p = geminiProvider.pricing.getPricing('gemini-2.5-flash-latest')
+      expect(p.inputPerMillion).toBe(0.15)
+    })
+    it('returns gemini-2.0-flash pricing', () => {
+      const p = geminiProvider.pricing.getPricing('gemini-2.0-flash')
+      expect(p.inputPerMillion).toBe(0.1)
+    })
+    it('falls back to gemini-2.5-flash for unknown', () => {
+      const p = geminiProvider.pricing.getPricing('unknown')
+      expect(p.model).toBe('gemini-2.5-flash')
+    })
+  })
+
+  describe('Aider', () => {
+    it('returns gpt-4o pricing', () => {
+      const p = aiderProvider.pricing.getPricing('gpt-4o-latest')
+      expect(p.inputPerMillion).toBe(2.5)
+    })
+    it('falls back to claude-sonnet-4-6 for unknown', () => {
+      const p = aiderProvider.pricing.getPricing('unknown-llm')
+      expect(p.model).toBe('claude-sonnet-4-6')
+    })
+  })
+
+  describe('Copilot', () => {
+    it('returns gpt-4o pricing', () => {
+      const p = copilotProvider.pricing.getPricing('gpt-4o')
+      expect(p.inputPerMillion).toBe(2.5)
+    })
+    it('falls back to zero-cost copilot-default for unknown', () => {
+      const p = copilotProvider.pricing.getPricing('unknown')
+      expect(p.model).toBe('copilot-default')
+      expect(p.inputPerMillion).toBe(0)
+    })
+  })
+
+  describe('Zed', () => {
+    it('returns claude-sonnet-4-6 pricing', () => {
+      const p = zedProvider.pricing.getPricing('claude-sonnet-4-6-latest')
+      expect(p.inputPerMillion).toBe(3.0)
+    })
+    it('falls back to claude-sonnet-4-6 for unknown', () => {
+      const p = zedProvider.pricing.getPricing('unknown')
+      expect(p.model).toBe('claude-sonnet-4-6')
+    })
+  })
+
+  describe('Amazon Q', () => {
+    it('returns zero-cost default for any model', () => {
+      const p = amazonqProvider.pricing.getPricing('anything')
+      expect(p.model).toBe('amazonq-default')
+      expect(p.inputPerMillion).toBe(0)
+      expect(p.outputPerMillion).toBe(0)
+    })
+  })
+
+  describe('All providers have valid PricingConfig shapes', () => {
+    for (const provider of ALL_PROVIDERS) {
+      it(`${provider.name}: defaultPricing has all required fields`, () => {
+        const dp = provider.pricing.defaultPricing
+        expect(typeof dp.model).toBe('string')
+        expect(typeof dp.inputPerMillion).toBe('number')
+        expect(typeof dp.outputPerMillion).toBe('number')
+        expect(typeof dp.cacheCreationPerMillion).toBe('number')
+        expect(typeof dp.cacheReadPerMillion).toBe('number')
+        expect(dp.inputPerMillion).toBeGreaterThanOrEqual(0)
+        expect(dp.outputPerMillion).toBeGreaterThanOrEqual(0)
+      })
+    }
+  })
+})
+
+// ===========================================================================
+// 5. Parser tests with sample data
+// ===========================================================================
+
+describe('Parser tests with sample data', () => {
+  describe('Codex parser', () => {
+    it('parseLine: parses a SessionMeta line', () => {
+      const line = JSON.stringify({
+        timestamp: '2025-05-07T17:24:21Z',
+        item: { id: 'session-123', cwd: '/home/user/project', cli_version: '0.1.0' },
+      })
+      const record = codexProvider.parser.parseLine(line)
+      expect(record).not.toBeNull()
+      expect(record!.type).toBe('user')
+      expect((record as { timestamp: string }).timestamp).toBe('2025-05-07T17:24:21Z')
+    })
+
+    it('parseLine: parses a TokenCount event', () => {
+      const line = JSON.stringify({
+        timestamp: '2025-05-07T17:25:00Z',
+        item: {
+          type: 'EventMsg',
+          event: {
+            type: 'TokenCount',
+            TokenCount: {
+              model: 'o4-mini',
+              input_tokens: 5000,
+              output_tokens: 1200,
+              input_tokens_cache_write: 200,
+              input_tokens_cache_read: 3000,
+            },
+          },
+        },
+      })
+      const record = codexProvider.parser.parseLine(line)
+      expect(record).not.toBeNull()
+      expect(record!.type).toBe('assistant')
+      const a = record as any
+      expect(a.message.usage.input_tokens).toBe(5000)
+      expect(a.message.usage.output_tokens).toBe(1200)
+      expect(a.message.model).toBe('o4-mini')
+    })
+
+    it('parseLine: parses a function_call ResponseItem', () => {
+      const line = JSON.stringify({
+        timestamp: '2025-05-07T17:25:10Z',
+        item: {
+          type: 'ResponseItem',
+          response_item: {
+            type: 'function_call',
+            name: 'shell',
+            call_id: 'call-1',
+            arguments: '{"command":["ls","-la"]}',
+          },
+        },
+      })
+      const record = codexProvider.parser.parseLine(line)
+      expect(record).not.toBeNull()
+      expect(record!.type).toBe('assistant')
+      const a = record as any
+      expect(a.message.content[0].type).toBe('tool_use')
+      expect(a.message.content[0].name).toBe('shell')
+    })
+
+    it('parseLine: returns null for empty line', () => {
+      expect(codexProvider.parser.parseLine('')).toBeNull()
+      expect(codexProvider.parser.parseLine('  ')).toBeNull()
+    })
+
+    it('parseLine: parses Compacted boundary', () => {
+      const line = JSON.stringify({
+        timestamp: '2025-05-07T18:00:00Z',
+        item: { Compacted: true },
+      })
+      const record = codexProvider.parser.parseLine(line)
+      expect(record).not.toBeNull()
+      expect(record!.type).toBe('compact_boundary')
+    })
+
+    it('extractTurns: produces TurnMetrics from assistant records with usage', () => {
+      const records = [
+        { type: 'user' as const, sessionId: '', timestamp: 'T0', message: { role: 'user' as const, content: 'hello' } },
+        {
+          type: 'assistant' as const, sessionId: '', timestamp: 'T1',
+          message: {
+            role: 'assistant' as const, model: 'o4-mini', content: [],
+            usage: { input_tokens: 500, output_tokens: 200, cache_creation_input_tokens: 0, cache_read_input_tokens: 100 },
+          },
+        },
+      ]
+      const turns = codexProvider.parser.extractTurns(records as any)
+      expect(turns).toHaveLength(1)
+      expect(turns[0].turnIndex).toBe(0)
+      expect(turns[0].usage.input_tokens).toBe(500)
+      expect(turns[0].cacheRatio).toBeCloseTo(100 / 600)
+    })
+
+    it('extractModel: returns last assistant model', () => {
+      const records = [
+        { type: 'assistant' as const, sessionId: '', timestamp: 'T1', message: { role: 'assistant' as const, model: 'gpt-4.1', content: [] } },
+        { type: 'assistant' as const, sessionId: '', timestamp: 'T2', message: { role: 'assistant' as const, model: 'o4-mini', content: [] } },
+      ]
+      expect(codexProvider.parser.extractModel(records as any)).toBe('o4-mini')
+    })
+
+    it('hasResumeBoundary: detects compact_boundary', () => {
+      const records = [
+        { type: 'user' as const, sessionId: '', timestamp: 'T0' },
+        { type: 'compact_boundary' as const },
+        { type: 'assistant' as const, sessionId: '', timestamp: 'T1' },
+      ]
+      expect(codexProvider.parser.hasResumeBoundary(records as any)).toBe(true)
+    })
+  })
+
+  describe('Windsurf parser', () => {
+    it('parseLine: parses user_input', () => {
+      const line = JSON.stringify({
+        type: 'user_input',
+        timestamp: '2025-06-01T10:00:00Z',
+        user_input: { text: 'fix the bug', cwd: '/home/dev/project' },
+      })
+      const record = windsurfProvider.parser.parseLine(line)
+      expect(record).not.toBeNull()
+      expect(record!.type).toBe('user')
+      const u = record as any
+      expect(u.message.content).toBe('fix the bug')
+      expect(u.cwd).toBe('/home/dev/project')
+    })
+
+    it('parseLine: parses planner_response with usage', () => {
+      const line = JSON.stringify({
+        type: 'planner_response',
+        timestamp: '2025-06-01T10:00:05Z',
+        planner_response: {
+          text: 'I will fix the bug by...',
+          model: 'claude-sonnet-4-6',
+          usage: { input_tokens: 3000, output_tokens: 500, cache_creation_input_tokens: 0, cache_read_input_tokens: 2000 },
+        },
+      })
+      const record = windsurfProvider.parser.parseLine(line)
+      expect(record).not.toBeNull()
+      expect(record!.type).toBe('assistant')
+      const a = record as any
+      expect(a.message.model).toBe('claude-sonnet-4-6')
+      expect(a.message.usage.input_tokens).toBe(3000)
+      expect(a.message.usage.cache_read_input_tokens).toBe(2000)
+    })
+
+    it('parseLine: parses code_action', () => {
+      const line = JSON.stringify({
+        type: 'code_action',
+        timestamp: '2025-06-01T10:00:10Z',
+        code_action: { tool_name: 'edit_file', parameters: { file_path: '/src/main.ts' } },
+      })
+      const record = windsurfProvider.parser.parseLine(line)
+      expect(record).not.toBeNull()
+      expect(record!.type).toBe('assistant')
+      const a = record as any
+      expect(a.message.content[0].name).toBe('edit_file')
+    })
+
+    it('parseLine: returns null for invalid JSON', () => {
+      expect(windsurfProvider.parser.parseLine('not valid json')).toBeNull()
+    })
+
+    it('extractTurns: produces turns from planner_response records', () => {
+      const records = [
+        {
+          type: 'assistant' as const, sessionId: '', timestamp: '2025-06-01T10:00:05Z',
+          message: {
+            role: 'assistant' as const, model: 'claude-sonnet-4-6',
+            content: [{ type: 'text' as const, text: 'analysis' }],
+            usage: { input_tokens: 3000, output_tokens: 500, cache_creation_input_tokens: 0, cache_read_input_tokens: 2000 },
+          },
+        },
+      ]
+      const turns = windsurfProvider.parser.extractTurns(records as any)
+      expect(turns).toHaveLength(1)
+      expect(turns[0].usage.input_tokens).toBe(3000)
+      expect(turns[0].cacheRatio).toBeCloseTo(2000 / 5000)
+    })
+
+    it('extractContext: extracts cwd from user records', () => {
+      const records = [
+        { type: 'user' as const, sessionId: '', timestamp: 'T0', message: { role: 'user' as const, content: 'hello' }, cwd: '/home/dev/myproject' },
+      ]
+      const ctx = windsurfProvider.parser.extractContext(records as any)
+      expect(ctx.cwd).toBe('/home/dev/myproject')
+      expect(ctx.projectName).toBe('myproject')
+    })
+  })
+
+  describe('Cline parser', () => {
+    it('parseLine: parses a JSON line', () => {
+      const line = JSON.stringify({ type: 'user', sessionId: 'abc', timestamp: 'T0', message: { role: 'user', content: 'test' } })
+      const record = clineProvider.parser.parseLine(line)
+      expect(record).not.toBeNull()
+      expect(record!.type).toBe('user')
+    })
+
+    it('extractTurns: extracts turns with tool calls', () => {
+      const records = [
+        {
+          type: 'assistant' as const, sessionId: '', timestamp: 'T1',
+          message: {
+            role: 'assistant' as const, model: 'claude-sonnet-4-6',
+            content: [
+              { type: 'text' as const, text: 'Let me read the file' },
+              { type: 'tool_use' as const, name: 'read_file', id: 'tu1', input: { path: '/src/app.ts' } },
+            ],
+            usage: { input_tokens: 2000, output_tokens: 300, cache_creation_input_tokens: 500, cache_read_input_tokens: 1000 },
+          },
+        },
+      ]
+      const turns = clineProvider.parser.extractTurns(records as any)
+      expect(turns).toHaveLength(1)
+      expect(turns[0].toolCalls).toHaveLength(1)
+      expect(turns[0].toolCalls[0].name).toBe('read_file')
+      expect(turns[0].cacheRatio).toBeCloseTo(1000 / 3500)
+    })
+
+    it('extractModel: returns last assistant model', () => {
+      const records = [
+        { type: 'assistant' as const, sessionId: '', timestamp: 'T1', message: { role: 'assistant' as const, model: 'gpt-4o', content: [] } },
+        { type: 'assistant' as const, sessionId: '', timestamp: 'T2', message: { role: 'assistant' as const, model: 'claude-sonnet-4-6', content: [] } },
+      ]
+      expect(clineProvider.parser.extractModel(records as any)).toBe('claude-sonnet-4-6')
+    })
+
+    it('hasResumeBoundary: returns false (Cline has no compaction)', () => {
+      expect(clineProvider.parser.hasResumeBoundary([])).toBe(false)
+    })
+  })
+
+  describe('Gemini parser', () => {
+    it('parseLine: parses a JSON line', () => {
+      const line = JSON.stringify({ type: 'user', sessionId: '', timestamp: 'T0', message: { role: 'user', content: 'hello' } })
+      const record = geminiProvider.parser.parseLine(line)
+      expect(record).not.toBeNull()
+    })
+
+    it('parseLine: returns null for invalid JSON', () => {
+      expect(geminiProvider.parser.parseLine('{{bad json')).toBeNull()
+    })
+
+    it('extractTurns: produces turns from records with usageMetadata-style usage', () => {
+      const records = [
+        {
+          type: 'assistant' as const, sessionId: '', timestamp: 'T1',
+          message: {
+            role: 'assistant' as const, model: 'gemini-2.5-pro',
+            content: [{ type: 'text' as const, text: 'Here is the answer' }],
+            usage: { input_tokens: 4000, output_tokens: 1000, cache_creation_input_tokens: 0, cache_read_input_tokens: 500 },
+          },
+        },
+      ]
+      const turns = geminiProvider.parser.extractTurns(records as any)
+      expect(turns).toHaveLength(1)
+      expect(turns[0].usage.input_tokens).toBe(4000)
+    })
+
+    it('extractModel: returns last model', () => {
+      const records = [
+        { type: 'assistant' as const, sessionId: '', timestamp: 'T1', message: { role: 'assistant' as const, model: 'gemini-2.5-pro', content: [] } },
+      ]
+      expect(geminiProvider.parser.extractModel(records as any)).toBe('gemini-2.5-pro')
+    })
+  })
+
+  describe('Aider parser', () => {
+    it('parseLine: returns null (Aider is markdown-based, not line-based)', () => {
+      expect(aiderProvider.parser.parseLine('> some user message')).toBeNull()
+    })
+
+    it('extractTurns: produces turns from assistant records with usage', () => {
+      const records = [
+        {
+          type: 'assistant' as const, sessionId: '', timestamp: 'T1',
+          message: {
+            role: 'assistant' as const, model: '',
+            content: [],
+            usage: { input_tokens: 4200, output_tokens: 1100, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+          },
+        },
+      ]
+      const turns = aiderProvider.parser.extractTurns(records as any)
+      expect(turns).toHaveLength(1)
+      expect(turns[0].usage.input_tokens).toBe(4200)
+      expect(turns[0].usage.output_tokens).toBe(1100)
+      expect(turns[0].cacheRatio).toBe(0)
+    })
+
+    it('hasResumeBoundary: always false', () => {
+      expect(aiderProvider.parser.hasResumeBoundary([])).toBe(false)
+    })
+  })
+
+  describe('Tier 3 parsers (Copilot, Zed, Amazon Q)', () => {
+    it('Copilot parser.extractTurns: returns empty (limited monitoring)', () => {
+      expect(copilotProvider.parser.extractTurns([])).toEqual([])
+    })
+    it('Zed parser.extractTurns: returns empty', () => {
+      expect(zedProvider.parser.extractTurns([])).toEqual([])
+    })
+    it('Amazon Q parser.extractTurns: returns empty', () => {
+      expect(amazonqProvider.parser.extractTurns([])).toEqual([])
+    })
+    it('All Tier 3 parsers: extractModel returns null', () => {
+      expect(copilotProvider.parser.extractModel([])).toBeNull()
+      expect(zedProvider.parser.extractModel([])).toBeNull()
+      expect(amazonqProvider.parser.extractModel([])).toBeNull()
+    })
+    it('All Tier 3 parsers: extractContext returns empty context', () => {
+      for (const p of TIER_3_PROVIDERS) {
+        const ctx = p.parser.extractContext([])
+        expect(ctx.cwd).toBeNull()
+        expect(ctx.gitBranch).toBeNull()
+        expect(ctx.projectName).toBeNull()
+        expect(ctx.firstUserMessage).toBeNull()
+      }
+    })
+  })
+})
+
+// ===========================================================================
+// 6. Hook manager tests (Tier 1 providers)
+// ===========================================================================
+
+describe('Hook manager tests (Tier 1)', () => {
+  const blockDecision: HookDecision = { decision: 'block', reason: 'dangerous command' }
+  const approveDecision: HookDecision = { decision: 'approve' }
+  const approveWithContext: HookDecision = { decision: 'approve', additionalContext: 'Proceed with caution' }
+
+  describe('Claude hooks', () => {
+    const hooks = claudeProvider.hooks!
+
+    it('supportedEvents includes key events', () => {
+      expect(hooks.supportedEvents).toContain('session_start')
+      expect(hooks.supportedEvents).toContain('user_prompt_submit')
+      expect(hooks.supportedEvents).toContain('post_tool_use')
+      expect(hooks.supportedEvents).toContain('stop')
+    })
+
+    it('eventName maps canonical to Claude-specific names', () => {
+      expect(hooks.eventName('session_start')).toBe('SessionStart')
+      expect(hooks.eventName('user_prompt_submit')).toBe('UserPromptSubmit')
+      expect(hooks.eventName('pre_tool_use')).toBe('PreToolUse')
+      expect(hooks.eventName('post_tool_use')).toBe('PostToolUse')
+      expect(hooks.eventName('stop')).toBe('Stop')
+    })
+
+    it('blockExitCode is 2', () => {
+      expect(hooks.blockExitCode).toBe(2)
+    })
+
+    it('formatOutput: block decision serializes to JSON', () => {
+      const output = hooks.formatOutput(blockDecision)
+      const parsed = JSON.parse(output)
+      expect(parsed.decision).toBe('block')
+      expect(parsed.reason).toBe('dangerous command')
+    })
+
+    it('formatOutput: approve decision serializes to JSON', () => {
+      const output = hooks.formatOutput(approveDecision)
+      const parsed = JSON.parse(output)
+      expect(parsed.decision).toBe('approve')
+    })
+  })
+
+  describe('Codex hooks', () => {
+    const hooks = codexProvider.hooks!
+
+    it('supportedEvents includes key events (no pre/post compact)', () => {
+      expect(hooks.supportedEvents).toContain('session_start')
+      expect(hooks.supportedEvents).toContain('user_prompt_submit')
+      expect(hooks.supportedEvents).toContain('pre_tool_use')
+      expect(hooks.supportedEvents).toContain('post_tool_use')
+      expect(hooks.supportedEvents).toContain('stop')
+      expect(hooks.supportedEvents).not.toContain('pre_compact')
+      expect(hooks.supportedEvents).not.toContain('post_compact')
+    })
+
+    it('eventName maps correctly and returns null for unsupported', () => {
+      expect(hooks.eventName('session_start')).toBe('SessionStart')
+      expect(hooks.eventName('pre_tool_use')).toBe('PreToolUse')
+      expect(hooks.eventName('pre_compact')).toBeNull()
+      expect(hooks.eventName('post_compact')).toBeNull()
+    })
+
+    it('blockExitCode is 2', () => {
+      expect(hooks.blockExitCode).toBe(2)
+    })
+
+    it('formatOutput: produces valid JSON', () => {
+      const output = hooks.formatOutput(blockDecision)
+      expect(() => JSON.parse(output)).not.toThrow()
+      expect(JSON.parse(output).decision).toBe('block')
+    })
+  })
+
+  describe('Cursor hooks', () => {
+    const hooks = cursorProvider.hooks!
+
+    it('supportedEvents does not include session_start', () => {
+      expect(hooks.supportedEvents).not.toContain('session_start')
+      expect(hooks.supportedEvents).toContain('user_prompt_submit')
+      expect(hooks.supportedEvents).toContain('pre_tool_use')
+      expect(hooks.supportedEvents).toContain('stop')
+    })
+
+    it('eventName maps to Cursor-specific names', () => {
+      expect(hooks.eventName('user_prompt_submit')).toBe('beforeSubmitPrompt')
+      expect(hooks.eventName('pre_tool_use')).toBe('beforeShellExecution')
+      expect(hooks.eventName('post_tool_use')).toBe('afterFileEdit')
+      expect(hooks.eventName('session_start')).toBeNull()
+    })
+
+    it('formatOutput: block produces Cursor deny format', () => {
+      const output = hooks.formatOutput(blockDecision)
+      const parsed = JSON.parse(output)
+      expect(parsed.continue).toBe(false)
+      expect(parsed.permission).toBe('deny')
+      expect(parsed.agentMessage).toBe('dangerous command')
+    })
+
+    it('formatOutput: approve produces Cursor allow format', () => {
+      const output = hooks.formatOutput(approveDecision)
+      const parsed = JSON.parse(output)
+      expect(parsed.continue).toBe(true)
+      expect(parsed.permission).toBe('allow')
+    })
+
+    it('formatOutput: approve with context includes agentMessage', () => {
+      const output = hooks.formatOutput(approveWithContext)
+      const parsed = JSON.parse(output)
+      expect(parsed.continue).toBe(true)
+      expect(parsed.agentMessage).toBe('Proceed with caution')
+    })
+  })
+
+  describe('Windsurf hooks', () => {
+    const hooks = windsurfProvider.hooks!
+
+    it('supportedEvents includes tool use and stop events', () => {
+      expect(hooks.supportedEvents).toContain('pre_tool_use')
+      expect(hooks.supportedEvents).toContain('post_tool_use')
+      expect(hooks.supportedEvents).toContain('stop')
+    })
+
+    it('eventName maps to Windsurf-specific names', () => {
+      expect(hooks.eventName('user_prompt_submit')).toBe('pre_user_prompt')
+      expect(hooks.eventName('pre_tool_use')).toBe('pre_run_command')
+      expect(hooks.eventName('post_tool_use')).toBe('post_run_command')
+      expect(hooks.eventName('stop')).toBe('post_cascade_response_with_transcript')
+      expect(hooks.eventName('session_start')).toBeNull()
+    })
+
+    it('blockExitCode is 2', () => {
+      expect(hooks.blockExitCode).toBe(2)
+    })
+
+    it('formatOutput: produces valid JSON', () => {
+      const output = hooks.formatOutput(blockDecision)
+      expect(() => JSON.parse(output)).not.toThrow()
+    })
+  })
+
+  describe('Cline hooks', () => {
+    const hooks = clineProvider.hooks!
+
+    it('supportedEvents includes unique Cline events', () => {
+      expect(hooks.supportedEvents).toContain('session_start')
+      expect(hooks.supportedEvents).toContain('pre_tool_use')
+      expect(hooks.supportedEvents).toContain('post_tool_use')
+      expect(hooks.supportedEvents).toContain('pre_compact')
+      expect(hooks.supportedEvents).toContain('stop')
+    })
+
+    it('eventName maps to Cline-specific names', () => {
+      expect(hooks.eventName('session_start')).toBe('TaskStart')
+      expect(hooks.eventName('pre_tool_use')).toBe('PreToolUse')
+      expect(hooks.eventName('post_tool_use')).toBe('PostToolUse')
+      expect(hooks.eventName('pre_compact')).toBe('PreCompact')
+      expect(hooks.eventName('stop')).toBe('TaskComplete')
+      expect(hooks.eventName('post_compact')).toBeNull()
+    })
+
+    it('blockExitCode is 1', () => {
+      expect(hooks.blockExitCode).toBe(1)
+    })
+
+    it('formatOutput: block produces Cline cancel format', () => {
+      const output = hooks.formatOutput(blockDecision)
+      const parsed = JSON.parse(output)
+      expect(parsed.cancel).toBe(true)
+      expect(parsed.errorMessage).toBe('dangerous command')
+    })
+
+    it('formatOutput: approve produces Cline non-cancel format', () => {
+      const output = hooks.formatOutput(approveDecision)
+      const parsed = JSON.parse(output)
+      expect(parsed.cancel).toBe(false)
+    })
+
+    it('formatOutput: approve with context includes contextModification', () => {
+      const output = hooks.formatOutput(approveWithContext)
+      const parsed = JSON.parse(output)
+      expect(parsed.cancel).toBe(false)
+      expect(parsed.contextModification).toBe('Proceed with caution')
+    })
+  })
+})
+
+// ===========================================================================
+// 7. Discovery tests — extractSessionId for sample paths
+// ===========================================================================
+
+describe('Discovery tests', () => {
+  describe('Claude', () => {
+    it('extractSessionId strips .jsonl extension', () => {
+      expect(claudeProvider.discovery.extractSessionId('/home/user/.claude/projects/myapp/session-abc123.jsonl'))
+        .toBe('session-abc123')
+    })
+    it('extractProjectPath extracts first path segment after base', () => {
+      const base = '/home/user/.claude/projects'
+      expect(claudeProvider.discovery.extractProjectPath(`${base}/myapp/session.jsonl`, base))
+        .toBe('myapp')
+    })
+    it('fileExtensions includes .jsonl', () => {
+      expect(claudeProvider.discovery.fileExtensions).toContain('.jsonl')
+    })
+  })
+
+  describe('Codex', () => {
+    it('extractSessionId strips .jsonl extension', () => {
+      expect(codexProvider.discovery.extractSessionId('/home/user/.codex/sessions/rollout-2025-05-07T17-24-21-abc.jsonl'))
+        .toBe('rollout-2025-05-07T17-24-21-abc')
+    })
+    it('extractProjectPath returns codex (no project structure)', () => {
+      expect(codexProvider.discovery.extractProjectPath('/any/path', '/base'))
+        .toBe('codex')
+    })
+  })
+
+  describe('Cursor', () => {
+    it('extractSessionId strips .vscdb extension', () => {
+      expect(cursorProvider.discovery.extractSessionId('/path/to/state.vscdb'))
+        .toBe('state')
+    })
+    it('fileExtensions includes .vscdb', () => {
+      expect(cursorProvider.discovery.fileExtensions).toContain('.vscdb')
+    })
+  })
+
+  describe('Windsurf', () => {
+    it('extractSessionId strips .jsonl for trajectory files', () => {
+      expect(windsurfProvider.discovery.extractSessionId('/home/user/.windsurf/transcripts/traj-abc123.jsonl'))
+        .toBe('traj-abc123')
+    })
+  })
+
+  describe('Cline', () => {
+    it('extractSessionId returns parent directory name (task ID)', () => {
+      expect(clineProvider.discovery.extractSessionId('/path/to/globalStorage/tasks/task-123/api_conversation_history.json'))
+        .toBe('task-123')
+    })
+    it('fileExtensions includes .json', () => {
+      expect(clineProvider.discovery.fileExtensions).toContain('.json')
+    })
+  })
+
+  describe('Gemini', () => {
+    it('extractSessionId strips .json extension', () => {
+      expect(geminiProvider.discovery.extractSessionId('/home/user/.gemini/history/session-001.json'))
+        .toBe('session-001')
+    })
+  })
+
+  describe('Aider', () => {
+    it('extractSessionId strips .md extension', () => {
+      expect(aiderProvider.discovery.extractSessionId('/home/user/project/.aider.chat.history.md'))
+        .toBe('.aider.chat.history')
+    })
+    it('fileExtensions includes .md', () => {
+      expect(aiderProvider.discovery.fileExtensions).toContain('.md')
+    })
+  })
+
+  describe('Copilot', () => {
+    it('extractSessionId strips .vscdb extension', () => {
+      expect(copilotProvider.discovery.extractSessionId('/path/workspace.vscdb'))
+        .toBe('workspace')
+    })
+  })
+
+  describe('Zed', () => {
+    it('extractSessionId returns basename', () => {
+      expect(zedProvider.discovery.extractSessionId('/path/to/zed.db'))
+        .toBe('zed.db')
+    })
+    it('fileExtensions includes .db', () => {
+      expect(zedProvider.discovery.fileExtensions).toContain('.db')
+    })
+  })
+
+  describe('Amazon Q', () => {
+    it('extractSessionId strips .json extension', () => {
+      expect(amazonqProvider.discovery.extractSessionId('/home/user/.aws/amazonq/session-xyz.json'))
+        .toBe('session-xyz')
+    })
+  })
+
+  describe('All providers have valid discovery config', () => {
+    for (const provider of ALL_PROVIDERS) {
+      it(`${provider.name}: watchDepth is a positive number`, () => {
+        expect(provider.discovery.watchDepth).toBeGreaterThan(0)
+      })
+      it(`${provider.name}: fileExtensions are non-empty and start with .`, () => {
+        for (const ext of provider.discovery.fileExtensions) {
+          expect(ext.startsWith('.')).toBe(true)
+        }
+      })
+    }
+  })
+})
+
+// ===========================================================================
+// 8. Tier classification sanity checks
+// ===========================================================================
+
+describe('Tier classification', () => {
+  it('Tier 1 providers: Claude, Codex, Cursor, Windsurf, Cline', () => {
+    const tier1Names = TIER_1_PROVIDERS.map((p) => p.name).sort()
+    expect(tier1Names).toEqual(['claude', 'cline', 'codex', 'cursor', 'windsurf'])
+  })
+
+  it('Tier 2 providers: Gemini, Aider', () => {
+    const tier2Names = TIER_2_PROVIDERS.map((p) => p.name).sort()
+    expect(tier2Names).toEqual(['aider', 'gemini'])
+  })
+
+  it('Tier 3 providers: Copilot, Zed, Amazon Q', () => {
+    const tier3Names = TIER_3_PROVIDERS.map((p) => p.name).sort()
+    expect(tier3Names).toEqual(['amazonq', 'copilot', 'zed'])
+  })
+
+  it('All Tier 1 providers have non-null hooks', () => {
+    for (const p of TIER_1_PROVIDERS) {
+      expect(p.hooks).not.toBeNull()
+    }
+  })
+
+  it('All Tier 2/3 providers have null hooks', () => {
+    for (const p of [...TIER_2_PROVIDERS, ...TIER_3_PROVIDERS]) {
+      expect(p.hooks).toBeNull()
+    }
+  })
+})
+
+// ===========================================================================
+// 9. Context limit tests
+// ===========================================================================
+
+describe('getContextLimit', () => {
+  it('Claude: Opus model returns 1M', () => {
+    expect(claudeProvider.getContextLimit('claude-opus-4-6')).toBe(1_000_000)
+  })
+
+  it('Claude: Haiku model returns 200K', () => {
+    expect(claudeProvider.getContextLimit('claude-haiku-4-5')).toBe(200_000)
+  })
+
+  it('Codex: gpt-4.1 returns 1M+', () => {
+    expect(codexProvider.getContextLimit('gpt-4.1')).toBe(1_047_576)
+  })
+
+  it('Codex: o3 returns 200K', () => {
+    expect(codexProvider.getContextLimit('o3-mini')).toBe(200_000)
+  })
+
+  it('Cursor: gpt-4o returns 128K', () => {
+    expect(cursorProvider.getContextLimit('gpt-4o')).toBe(128_000)
+  })
+
+  it('Gemini: pro returns 1M', () => {
+    expect(geminiProvider.getContextLimit('gemini-2.5-pro')).toBe(1_000_000)
+  })
+
+  it('Cline: deepseek returns 128K', () => {
+    expect(clineProvider.getContextLimit('deepseek-chat')).toBe(128_000)
+  })
+})

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1,0 +1,76 @@
+/**
+ * Provider registry — central lookup for all registered AI tool providers.
+ *
+ * Providers register themselves at import time. The registry supports:
+ * - Explicit lookup by name (e.g. --provider codex)
+ * - Auto-detection of installed tools
+ * - Matching a session file path to its provider
+ */
+
+import { existsSync } from 'node:fs'
+import type { Provider } from './types.js'
+
+export class ProviderRegistry {
+  private providers = new Map<string, Provider>()
+
+  /** Register a provider. Overwrites if name already exists. */
+  register(provider: Provider): void {
+    this.providers.set(provider.name, provider)
+  }
+
+  /** Get a provider by name. Throws if not found. */
+  get(name: string): Provider {
+    const provider = this.providers.get(name)
+    if (!provider) {
+      const available = [...this.providers.keys()].join(', ')
+      throw new Error(`Unknown provider "${name}". Available: ${available}`)
+    }
+    return provider
+  }
+
+  /** Get a provider by name, or null if not found. */
+  find(name: string): Provider | null {
+    return this.providers.get(name) ?? null
+  }
+
+  /** Get all registered providers. */
+  getAll(): Provider[] {
+    return [...this.providers.values()]
+  }
+
+  /** Get all provider names. */
+  names(): string[] {
+    return [...this.providers.keys()]
+  }
+
+  /**
+   * Auto-detect which providers are installed by checking if their
+   * config/session directories exist on this machine.
+   */
+  detect(): Provider[] {
+    return this.getAll().filter((p) => {
+      try {
+        return existsSync(p.directories.configDir())
+      } catch {
+        return false
+      }
+    })
+  }
+
+  /**
+   * Find the provider that owns a given session file path.
+   * Checks if the file path starts with the provider's sessions directory.
+   */
+  forSessionFile(filePath: string): Provider | null {
+    for (const provider of this.providers.values()) {
+      const sessDir = provider.directories.sessionsDir()
+      if (filePath.startsWith(sessDir)) {
+        return provider
+      }
+    }
+    return null
+  }
+}
+
+/** Singleton registry instance — providers register on import. */
+export const registry = new ProviderRegistry()

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,0 +1,185 @@
+/**
+ * Provider abstraction layer — enables clauditor to work with any AI coding tool.
+ *
+ * Each provider (Claude Code, Codex, Cursor, Windsurf, Cline, etc.) implements
+ * these interfaces to plug into clauditor's features (cache health, loop detection,
+ * error index, handoffs, cost tracking, hub sync).
+ */
+
+import type {
+  SessionRecord,
+  TurnMetrics,
+  TokenUsage,
+  PricingConfig,
+  HookDecision,
+} from '../types.js'
+
+// ---------------------------------------------------------------------------
+// Canonical tool names — features operate on these, never provider-specific names
+// ---------------------------------------------------------------------------
+
+export type CanonicalTool =
+  | 'bash_execute'
+  | 'file_read'
+  | 'file_write'
+  | 'file_edit'
+  | 'file_search'
+  | 'web_search'
+  | 'web_fetch'
+  | 'browser'
+  | 'mcp_tool'
+  | 'other'
+
+// ---------------------------------------------------------------------------
+// Canonical hook events — mapped to/from provider-specific event names
+// ---------------------------------------------------------------------------
+
+export type CanonicalHookEvent =
+  | 'session_start'
+  | 'user_prompt_submit'
+  | 'pre_tool_use'
+  | 'post_tool_use'
+  | 'pre_compact'
+  | 'post_compact'
+  | 'stop'
+
+// ---------------------------------------------------------------------------
+// Provider capability tiers
+// ---------------------------------------------------------------------------
+
+export type ProviderTier = 1 | 2 | 3
+// Tier 1: Full hooks + session monitoring (Claude, Codex, Cursor, Windsurf, Cline)
+// Tier 2: Session monitoring only, no hooks (Gemini CLI, Aider)
+// Tier 3: Limited monitoring (Copilot, Zed, Amazon Q)
+
+// ---------------------------------------------------------------------------
+// Core provider interface
+// ---------------------------------------------------------------------------
+
+export interface Provider {
+  /** Short identifier: 'claude', 'codex', 'cursor', etc. */
+  name: string
+  /** Human-readable: 'Claude Code', 'Codex CLI', etc. */
+  displayName: string
+  /** Capability tier */
+  tier: ProviderTier
+
+  /** Directory resolution */
+  directories: DirectoryResolver
+  /** Session parsing — provider format → canonical TurnMetrics */
+  parser: SessionParser
+  /** Session file discovery and identification */
+  discovery: SessionDiscovery
+  /** Model pricing */
+  pricing: PricingResolver
+  /** Tool name mapping */
+  tools: ToolNameMapper
+
+  /** Hook system (null for Tier 2/3 providers without hooks) */
+  hooks: HookManager | null
+
+  /** Context window limit for a given model */
+  getContextLimit(model: string): number
+}
+
+// ---------------------------------------------------------------------------
+// Directory resolution
+// ---------------------------------------------------------------------------
+
+export interface DirectoryResolver {
+  /** Where the provider stores session data (e.g. ~/.claude/projects) */
+  sessionsDir(): string
+  /** Provider config directory (e.g. ~/.claude) */
+  configDir(): string
+  /** Clauditor shared state directory — always ~/.clauditor */
+  stateDir(): string
+}
+
+// ---------------------------------------------------------------------------
+// Session parsing
+// ---------------------------------------------------------------------------
+
+export interface SessionContext {
+  cwd: string | null
+  gitBranch: string | null
+  projectName: string | null
+  firstUserMessage: string | null
+}
+
+export interface SessionParser {
+  /** Parse a single line/record from the provider's session format */
+  parseLine(line: string): SessionRecord | null
+  /** Parse an entire session file into records */
+  parseFile(filePath: string): Promise<SessionRecord[]>
+  /** Extract turn metrics from parsed records */
+  extractTurns(records: SessionRecord[]): TurnMetrics[]
+  /** Extract model ID from records */
+  extractModel(records: SessionRecord[]): string | null
+  /** Extract session context (cwd, git branch, etc.) */
+  extractContext(records: SessionRecord[]): SessionContext
+  /** Check for resume/compaction boundaries */
+  hasResumeBoundary(records: SessionRecord[]): boolean
+}
+
+// ---------------------------------------------------------------------------
+// Session discovery
+// ---------------------------------------------------------------------------
+
+export interface SessionDiscovery {
+  /** File extensions to watch (e.g. ['.jsonl'], ['.json']) */
+  fileExtensions: string[]
+  /** Glob depth for directory watching */
+  watchDepth: number
+  /** Extract session ID from a file path */
+  extractSessionId(filePath: string): string
+  /** Extract project identifier from a file path */
+  extractProjectPath(filePath: string, baseDir: string): string
+}
+
+// ---------------------------------------------------------------------------
+// Pricing
+// ---------------------------------------------------------------------------
+
+export interface PricingResolver {
+  /** All known models for this provider */
+  models: Record<string, PricingConfig>
+  /** Get pricing for a model ID (supports prefix matching) */
+  getPricing(modelId: string): PricingConfig
+  /** Default model pricing (fallback) */
+  defaultPricing: PricingConfig
+}
+
+// ---------------------------------------------------------------------------
+// Tool name mapping
+// ---------------------------------------------------------------------------
+
+export interface ToolNameMapper {
+  /** Map provider-specific tool name to canonical name */
+  toCanonical(providerToolName: string): CanonicalTool
+  /** Map canonical name back to provider's primary tool name */
+  fromCanonical(canonical: CanonicalTool): string
+  /** Extract a short readable label from tool input (e.g. "npm test" for bash) */
+  extractInputLabel(toolName: string, input: unknown): string
+}
+
+// ---------------------------------------------------------------------------
+// Hook management
+// ---------------------------------------------------------------------------
+
+export interface HookManager {
+  /** Hook event names this provider supports */
+  supportedEvents: CanonicalHookEvent[]
+  /** Exit code for blocking actions */
+  blockExitCode: number
+
+  /** Map canonical event to provider-specific event name (null if unsupported) */
+  eventName(canonical: CanonicalHookEvent): string | null
+
+  /** Install clauditor hooks into the provider's config */
+  install(): Promise<string[]>
+  /** Uninstall clauditor hooks from the provider's config */
+  uninstall(): Promise<string[]>
+
+  /** Format a HookDecision into the provider's expected output format */
+  formatOutput(decision: HookDecision): string
+}

--- a/src/providers/windsurf/discovery.ts
+++ b/src/providers/windsurf/discovery.ts
@@ -1,0 +1,16 @@
+import { basename } from 'node:path'
+import type { SessionDiscovery } from '../types.js'
+
+export const windsurfDiscovery: SessionDiscovery = {
+  fileExtensions: ['.jsonl'],
+  watchDepth: 1, // ~/.windsurf/transcripts/ is flat
+
+  extractSessionId(filePath: string): string {
+    // trajectory_id is the filename without extension
+    return basename(filePath).replace('.jsonl', '')
+  },
+
+  extractProjectPath(filePath: string, _baseDir: string): string {
+    return 'windsurf'
+  },
+}

--- a/src/providers/windsurf/hooks.ts
+++ b/src/providers/windsurf/hooks.ts
@@ -1,0 +1,135 @@
+/**
+ * Windsurf hook manager — installs/uninstalls clauditor hooks
+ * into ~/.codeium/windsurf/hooks.json.
+ *
+ * Windsurf has 12 hook events. Pre-hooks can block with exit code 2.
+ * Hook stdin: { agent_action_name, trajectory_id, execution_id, timestamp, tool_info }
+ */
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { homedir } from 'node:os'
+import type { HookManager, CanonicalHookEvent } from '../types.js'
+import type { HookDecision } from '../../types.js'
+
+const WINDSURF_HOOKS_PATH = resolve(homedir(), '.codeium/windsurf/hooks.json')
+const CLAUDITOR_MARKER = 'clauditor hook'
+
+const EVENT_MAP: Record<CanonicalHookEvent, string | null> = {
+  session_start: null,
+  user_prompt_submit: 'pre_user_prompt',
+  pre_tool_use: 'pre_run_command',
+  post_tool_use: 'post_run_command',
+  pre_compact: null,
+  post_compact: null,
+  stop: 'post_cascade_response_with_transcript',
+}
+
+interface WindsurfHookEntry {
+  command: string
+  show_output?: boolean
+  working_directory?: string
+}
+
+interface WindsurfHooksFile {
+  hooks: Record<string, WindsurfHookEntry[]>
+}
+
+function getHookCommand(subcommand: string): string {
+  const isNpx = process.argv[1]?.includes('_npx') || process.env.npm_execpath?.includes('npx')
+  if (isNpx) {
+    return `npx -y @iyadhk/clauditor hook ${subcommand} --provider windsurf`
+  }
+  return `clauditor hook ${subcommand} --provider windsurf`
+}
+
+const HOOK_COMMANDS: Record<string, string> = {
+  pre_user_prompt: getHookCommand('user-prompt-submit'),
+  pre_run_command: getHookCommand('pre-tool-use'),
+  post_run_command: getHookCommand('post-tool-use'),
+  pre_write_code: getHookCommand('pre-tool-use'),
+  post_write_code: getHookCommand('post-tool-use'),
+  post_cascade_response_with_transcript: getHookCommand('stop'),
+}
+
+async function readHooksFile(): Promise<WindsurfHooksFile> {
+  try {
+    const content = await readFile(WINDSURF_HOOKS_PATH, 'utf-8')
+    return JSON.parse(content)
+  } catch {
+    return { hooks: {} }
+  }
+}
+
+async function writeHooksFile(data: WindsurfHooksFile): Promise<void> {
+  await mkdir(dirname(WINDSURF_HOOKS_PATH), { recursive: true })
+  await writeFile(WINDSURF_HOOKS_PATH, JSON.stringify(data, null, 2) + '\n')
+}
+
+export const windsurfHooks: HookManager = {
+  supportedEvents: [
+    'user_prompt_submit',
+    'pre_tool_use',
+    'post_tool_use',
+    'stop',
+  ] as CanonicalHookEvent[],
+
+  blockExitCode: 2, // Same as Claude
+
+  eventName(canonical: CanonicalHookEvent): string | null {
+    return EVENT_MAP[canonical] ?? null
+  },
+
+  async install(): Promise<string[]> {
+    const file = await readHooksFile()
+    const messages: string[] = []
+
+    for (const [eventName, command] of Object.entries(HOOK_COMMANDS)) {
+      if (!file.hooks[eventName]) {
+        file.hooks[eventName] = []
+      }
+
+      const alreadyInstalled = file.hooks[eventName].some(
+        entry => entry.command.includes(CLAUDITOR_MARKER)
+      )
+
+      if (alreadyInstalled) {
+        messages.push(`${eventName}: already installed (skipped)`)
+        continue
+      }
+
+      file.hooks[eventName].push({ command, show_output: true })
+      messages.push(`${eventName}: ✓ installed`)
+    }
+
+    await writeHooksFile(file)
+    messages.push(`\nHooks written to ${WINDSURF_HOOKS_PATH}`)
+    return messages
+  },
+
+  async uninstall(): Promise<string[]> {
+    const file = await readHooksFile()
+    const messages: string[] = []
+
+    for (const eventName of Object.keys(file.hooks)) {
+      const before = file.hooks[eventName].length
+      file.hooks[eventName] = file.hooks[eventName].filter(
+        entry => !entry.command.includes(CLAUDITOR_MARKER)
+      )
+      const removed = before - file.hooks[eventName].length
+      if (removed > 0) {
+        messages.push(`${eventName}: ✓ removed ${removed} clauditor hook(s)`)
+      }
+      if (file.hooks[eventName].length === 0) {
+        delete file.hooks[eventName]
+      }
+    }
+
+    await writeHooksFile(file)
+    messages.push(`\nHooks written to ${WINDSURF_HOOKS_PATH}`)
+    return messages
+  },
+
+  formatOutput(decision: HookDecision): string {
+    return JSON.stringify(decision)
+  },
+}

--- a/src/providers/windsurf/index.ts
+++ b/src/providers/windsurf/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Windsurf (Cascade) provider.
+ *
+ * Windsurf has:
+ * - JSONL transcripts in ~/.windsurf/transcripts/
+ * - 12 hook events (most of any tool)
+ * - Dual-agent architecture (planner + executor)
+ */
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import type { Provider } from '../types.js'
+import { windsurfParser } from './parser.js'
+import { windsurfDiscovery } from './discovery.js'
+import { windsurfPricing } from './pricing.js'
+import { windsurfTools } from './tools.js'
+import { windsurfHooks } from './hooks.js'
+
+export const windsurfProvider: Provider = {
+  name: 'windsurf',
+  displayName: 'Windsurf',
+  tier: 1,
+
+  directories: {
+    sessionsDir: () => resolve(homedir(), '.windsurf/transcripts'),
+    configDir: () => resolve(homedir(), '.codeium/windsurf'),
+    stateDir: () => resolve(homedir(), '.clauditor'),
+  },
+
+  parser: windsurfParser,
+  discovery: windsurfDiscovery,
+  pricing: windsurfPricing,
+  tools: windsurfTools,
+  hooks: windsurfHooks,
+
+  getContextLimit(model: string): number {
+    if (model.includes('claude') && model.includes('opus')) return 1_000_000
+    if (model.includes('claude')) return 200_000
+    if (model.includes('gpt-4o')) return 128_000
+    if (model.includes('gemini')) return 1_000_000
+    return 200_000
+  },
+}

--- a/src/providers/windsurf/parser.ts
+++ b/src/providers/windsurf/parser.ts
@@ -1,0 +1,168 @@
+/**
+ * Windsurf (Cascade) session parser.
+ *
+ * Windsurf stores transcripts as JSONL at ~/.windsurf/transcripts/{trajectory_id}.jsonl
+ * Each line has: { status, type, [type_name]: { ... } }
+ * Types: user_input, planner_response, code_action
+ */
+import { readFile } from 'node:fs/promises'
+import type { SessionRecord, AssistantRecord, UserRecord, TurnMetrics, TokenUsage, ToolCallSummary } from '../../types.js'
+import type { SessionParser, SessionContext } from '../types.js'
+
+function parseWindsurfLine(line: string): SessionRecord | null {
+  const trimmed = line.trim()
+  if (!trimmed) return null
+
+  try {
+    const parsed = JSON.parse(trimmed)
+    if (!parsed.type) return null
+
+    const timestamp = parsed.timestamp || new Date().toISOString()
+
+    switch (parsed.type) {
+      case 'user_input': {
+        const input = parsed.user_input || {}
+        return {
+          type: 'user',
+          sessionId: '',
+          timestamp,
+          message: {
+            role: 'user' as const,
+            content: input.text || input.message || '',
+          },
+          cwd: input.cwd || undefined,
+        } as UserRecord
+      }
+
+      case 'planner_response': {
+        const response = parsed.planner_response || {}
+        return {
+          type: 'assistant',
+          sessionId: '',
+          timestamp,
+          message: {
+            role: 'assistant' as const,
+            model: response.model || '',
+            content: response.text ? [{ type: 'text' as const, text: response.text }] : [],
+            usage: response.usage ? {
+              input_tokens: response.usage.input_tokens || 0,
+              output_tokens: response.usage.output_tokens || 0,
+              cache_creation_input_tokens: response.usage.cache_creation_input_tokens || 0,
+              cache_read_input_tokens: response.usage.cache_read_input_tokens || 0,
+            } : undefined,
+          },
+        } as AssistantRecord
+      }
+
+      case 'code_action': {
+        const action = parsed.code_action || {}
+        const toolName = action.tool_name || action.action_type || 'unknown'
+        return {
+          type: 'assistant',
+          sessionId: '',
+          timestamp,
+          message: {
+            role: 'assistant' as const,
+            model: '',
+            content: [{
+              type: 'tool_use' as const,
+              name: toolName,
+              input: action.parameters || action.input || {},
+            }],
+          },
+        } as AssistantRecord
+      }
+
+      default:
+        return { type: parsed.type, sessionId: '', timestamp }
+    }
+  } catch {
+    return null
+  }
+}
+
+export const windsurfParser: SessionParser = {
+  parseLine: parseWindsurfLine,
+
+  async parseFile(filePath: string): Promise<SessionRecord[]> {
+    const content = await readFile(filePath, 'utf-8')
+    const records: SessionRecord[] = []
+    for (const line of content.split('\n')) {
+      const record = parseWindsurfLine(line)
+      if (record) records.push(record)
+    }
+    return records
+  },
+
+  extractTurns(records: SessionRecord[]): TurnMetrics[] {
+    const turns: TurnMetrics[] = []
+    let turnIndex = 0
+
+    for (const record of records) {
+      if (record.type !== 'assistant') continue
+      const assistant = record as AssistantRecord
+      if (!assistant.message?.usage) continue
+
+      const usage = normalizeUsage(assistant.message.usage)
+      const totalInput = usage.input_tokens + usage.cache_creation_input_tokens + usage.cache_read_input_tokens
+      const cacheRatio = totalInput > 0 ? usage.cache_read_input_tokens / totalInput : 0
+
+      const toolCalls: ToolCallSummary[] = (assistant.message.content || [])
+        .filter(block => block.type === 'tool_use')
+        .map(block => ({
+          name: block.name || 'unknown',
+          inputHash: '',
+          outputHash: '',
+        }))
+
+      turns.push({ turnIndex: turnIndex++, timestamp: assistant.timestamp, usage, cacheRatio, toolCalls })
+    }
+
+    return turns
+  },
+
+  extractModel(records: SessionRecord[]): string | null {
+    for (let i = records.length - 1; i >= 0; i--) {
+      const r = records[i]
+      if (r.type === 'assistant') {
+        const model = (r as AssistantRecord).message?.model
+        if (model) return model
+      }
+    }
+    return null
+  },
+
+  extractContext(records: SessionRecord[]): SessionContext {
+    let cwd: string | null = null
+    let firstUserMessage: string | null = null
+
+    for (const record of records) {
+      if (record.type === 'user') {
+        const user = record as UserRecord
+        if (!cwd && user.cwd) cwd = user.cwd
+        if (!firstUserMessage) {
+          const content = user.message?.content
+          if (typeof content === 'string' && content.trim()) {
+            firstUserMessage = content.trim()
+          }
+        }
+      }
+    }
+
+    const projectName = cwd ? cwd.split(/[/\\]/).filter(Boolean).pop() ?? null : null
+    return { cwd, gitBranch: null, projectName, firstUserMessage }
+  },
+
+  hasResumeBoundary(records: SessionRecord[]): boolean {
+    return records.some(r => r.type === 'compact_boundary')
+  },
+}
+
+function normalizeUsage(usage: Partial<TokenUsage>): TokenUsage {
+  return {
+    input_tokens: usage.input_tokens ?? 0,
+    output_tokens: usage.output_tokens ?? 0,
+    cache_creation_input_tokens: usage.cache_creation_input_tokens ?? 0,
+    cache_read_input_tokens: usage.cache_read_input_tokens ?? 0,
+  }
+}

--- a/src/providers/windsurf/pricing.ts
+++ b/src/providers/windsurf/pricing.ts
@@ -1,0 +1,50 @@
+import type { PricingConfig } from '../../types.js'
+import type { PricingResolver } from '../types.js'
+
+/**
+ * Windsurf pricing — beyond-quota pricing as of early 2026.
+ * Windsurf uses a credit system for most users, but charges per-token
+ * beyond quota limits.
+ */
+export const WINDSURF_MODELS: Record<string, PricingConfig> = {
+  'claude-sonnet-4-6': {
+    model: 'claude-sonnet-4-6',
+    inputPerMillion: 3.0,
+    outputPerMillion: 15.0,
+    cacheCreationPerMillion: 3.75,
+    cacheReadPerMillion: 0.3,
+  },
+  'gpt-4o': {
+    model: 'gpt-4o',
+    inputPerMillion: 2.5,
+    outputPerMillion: 10.0,
+    cacheCreationPerMillion: 3.125,
+    cacheReadPerMillion: 1.25,
+  },
+  'gemini-2.5-pro': {
+    model: 'gemini-2.5-pro',
+    inputPerMillion: 1.25,
+    outputPerMillion: 10.0,
+    cacheCreationPerMillion: 1.5625,
+    cacheReadPerMillion: 0.3125,
+  },
+  // Windsurf beyond-quota flat rate
+  'windsurf-default': {
+    model: 'windsurf-default',
+    inputPerMillion: 0.5,
+    outputPerMillion: 2.0,
+    cacheCreationPerMillion: 0.625,
+    cacheReadPerMillion: 0.1,
+  },
+}
+
+export const windsurfPricing: PricingResolver = {
+  models: WINDSURF_MODELS,
+  defaultPricing: WINDSURF_MODELS['windsurf-default'],
+  getPricing(modelId: string): PricingConfig {
+    for (const [key, pricing] of Object.entries(WINDSURF_MODELS)) {
+      if (modelId.startsWith(key)) return pricing
+    }
+    return this.defaultPricing
+  },
+}

--- a/src/providers/windsurf/tools.ts
+++ b/src/providers/windsurf/tools.ts
@@ -1,0 +1,61 @@
+import type { ToolNameMapper, CanonicalTool } from '../types.js'
+
+const TOOL_MAP: Record<string, CanonicalTool> = {
+  run_command: 'bash_execute',
+  edit_file: 'file_edit',
+  write_file: 'file_write',
+  view_file: 'file_read',
+  view_code_item: 'file_read',
+  find: 'file_search',
+  grep_search: 'file_search',
+  list_directory: 'file_read',
+  codebase_search: 'file_search',
+  search_web: 'web_search',
+  read_url_content: 'web_fetch',
+  view_web_document_chunk: 'web_fetch',
+}
+
+const REVERSE_MAP: Record<CanonicalTool, string> = {
+  bash_execute: 'run_command',
+  file_read: 'view_file',
+  file_write: 'write_file',
+  file_edit: 'edit_file',
+  file_search: 'grep_search',
+  web_search: 'search_web',
+  web_fetch: 'read_url_content',
+  browser: 'search_web',
+  mcp_tool: 'run_command',
+  other: 'run_command',
+}
+
+export const windsurfTools: ToolNameMapper = {
+  toCanonical(providerToolName: string): CanonicalTool {
+    return TOOL_MAP[providerToolName] ?? 'other'
+  },
+
+  fromCanonical(canonical: CanonicalTool): string {
+    return REVERSE_MAP[canonical] ?? 'run_command'
+  },
+
+  extractInputLabel(toolName: string, input: unknown): string {
+    if (!input || typeof input !== 'object') return ''
+    const obj = input as Record<string, unknown>
+
+    switch (toolName) {
+      case 'run_command': {
+        const cmd = typeof obj.command === 'string' ? obj.command : ''
+        return cmd.split('\n')[0].trim().slice(0, 60)
+      }
+      case 'edit_file':
+      case 'write_file':
+      case 'view_file': {
+        const fp = typeof obj.file_path === 'string'
+          ? obj.file_path
+          : typeof obj.path === 'string' ? obj.path : ''
+        return fp.split(/[/\\]/).pop() || ''
+      }
+      default:
+        return ''
+    }
+  },
+}

--- a/src/providers/zed/index.ts
+++ b/src/providers/zed/index.ts
@@ -1,0 +1,69 @@
+/**
+ * Zed AI provider (Tier 3 — limited monitoring).
+ *
+ * Zed stores conversations in its internal SQLite database.
+ * Extensions are WASM-based (no shell hook support).
+ */
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import { basename } from 'node:path'
+import type { Provider, SessionParser, SessionDiscovery, PricingResolver, ToolNameMapper, CanonicalTool, SessionContext } from '../types.js'
+import type { PricingConfig, SessionRecord, TurnMetrics } from '../../types.js'
+
+const ZED_MODELS: Record<string, PricingConfig> = {
+  'claude-sonnet-4-6': { model: 'claude-sonnet-4-6', inputPerMillion: 3.0, outputPerMillion: 15.0, cacheCreationPerMillion: 3.75, cacheReadPerMillion: 0.3 },
+  'gpt-4o': { model: 'gpt-4o', inputPerMillion: 2.5, outputPerMillion: 10.0, cacheCreationPerMillion: 3.125, cacheReadPerMillion: 1.25 },
+}
+
+const pricing: PricingResolver = {
+  models: ZED_MODELS,
+  defaultPricing: ZED_MODELS['claude-sonnet-4-6'],
+  getPricing(modelId: string): PricingConfig {
+    for (const [key, p] of Object.entries(ZED_MODELS)) { if (modelId.startsWith(key)) return p }
+    return this.defaultPricing
+  },
+}
+
+const tools: ToolNameMapper = {
+  toCanonical(name: string): CanonicalTool {
+    const map: Record<string, CanonicalTool> = { read_file: 'file_read', edit_file: 'file_edit', create_file: 'file_write', run_terminal_command: 'bash_execute', search_files: 'file_search', list_directory: 'file_read', diagnostics: 'other' }
+    return map[name] ?? 'other'
+  },
+  fromCanonical(c: CanonicalTool): string { return c === 'bash_execute' ? 'run_terminal_command' : 'read_file' },
+  extractInputLabel(): string { return '' },
+}
+
+const parser: SessionParser = {
+  parseLine(): SessionRecord | null { return null },
+  async parseFile(): Promise<SessionRecord[]> { return [] },
+  extractTurns(): TurnMetrics[] { return [] },
+  extractModel(): string | null { return null },
+  extractContext(): SessionContext { return { cwd: null, gitBranch: null, projectName: null, firstUserMessage: null } },
+  hasResumeBoundary(): boolean { return false },
+}
+
+const discovery: SessionDiscovery = {
+  fileExtensions: ['.db'],
+  watchDepth: 1,
+  extractSessionId(fp: string): string { return basename(fp) },
+  extractProjectPath(): string { return 'zed' },
+}
+
+function getZedDataDir(): string {
+  if (process.platform === 'darwin') return resolve(homedir(), 'Library/Application Support/Zed')
+  return resolve(homedir(), '.local/share/zed')
+}
+
+export const zedProvider: Provider = {
+  name: 'zed',
+  displayName: 'Zed AI',
+  tier: 3,
+  directories: {
+    sessionsDir: () => resolve(getZedDataDir(), 'db'),
+    configDir: () => resolve(homedir(), '.config/zed'),
+    stateDir: () => resolve(homedir(), '.clauditor'),
+  },
+  parser, discovery, pricing, tools,
+  hooks: null,
+  getContextLimit(): number { return 200_000 },
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,33 +214,14 @@ export interface HookDecision {
 }
 
 // Model pricing table
+// NOTE: Canonical pricing now lives in src/providers/claude/pricing.ts.
+// This re-export preserves backward compatibility for existing imports.
 
-export const MODEL_PRICING: Record<string, PricingConfig> = {
-  'claude-sonnet-4-6': {
-    model: 'claude-sonnet-4-6',
-    inputPerMillion: 3.0,
-    outputPerMillion: 15.0,
-    cacheCreationPerMillion: 3.75,
-    cacheReadPerMillion: 0.3,
-  },
-  'claude-opus-4-6': {
-    model: 'claude-opus-4-6',
-    inputPerMillion: 15.0,
-    outputPerMillion: 75.0,
-    cacheCreationPerMillion: 18.75,
-    cacheReadPerMillion: 1.5,
-  },
-  'claude-haiku-4-5': {
-    model: 'claude-haiku-4-5',
-    inputPerMillion: 0.8,
-    outputPerMillion: 4.0,
-    cacheCreationPerMillion: 1.0,
-    cacheReadPerMillion: 0.08,
-  },
-}
+import { CLAUDE_MODELS } from './providers/claude/pricing.js'
+export { CLAUDE_MODELS as MODEL_PRICING } from './providers/claude/pricing.js'
 
 export const DEFAULT_CONFIG: ClauditorConfig = {
-  pricing: MODEL_PRICING['claude-sonnet-4-6'],
+  pricing: CLAUDE_MODELS['claude-sonnet-4-6'],
   alerts: {
     cacheBugThreshold: 3,
     loopDetectionThreshold: 3,


### PR DESCRIPTION
## Summary
- Adds a provider abstraction layer enabling clauditor to work with any AI coding tool
- Implements 10 providers across 3 tiers: Claude Code, Codex CLI, Cursor, Windsurf, Cline, Gemini CLI, Aider, GitHub Copilot, Zed AI, Amazon Q
- Auto-detect installed tools on `clauditor install` and `clauditor login`
- Canonical tool names so features never branch on provider-specific names
- 262 new provider tests, 588 total passing

## Test plan
- [ ] `npx tsc --noEmit` — clean build
- [ ] `npx vitest run` — 588/588 tests pass
- [ ] `clauditor providers` — lists all 10 tools with detection status
- [ ] `clauditor install` (no flags) — auto-detects and installs for all detected tools
- [ ] `clauditor install --provider codex` — installs hooks for specific provider