### PR TITLE
fix: clearer error when clauditor login runs outside a git repo

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -199,8 +199,9 @@ program
 
     const remoteUrl = getGitRemoteUrl()
     if (!remoteUrl) {
-      console.error('\n  ✗ Not a git repo with a remote origin.')
-      console.error('    Run this from inside a git repo with a remote configured.')
+      console.error('\n  ✗ Hub features require a git repo with a remote.')
+      console.error('    cd into your project directory, then run `clauditor login`.')
+      console.error('    If you just want hooks without hub sync, run `clauditor install`.')
       process.exit(1)
     }
 


### PR DESCRIPTION
## Summary
- Replaces vague "Not a git repo with a remote origin" error with an actionable message
- Tells users the primary path (`cd` into project, then login) and the alternative (`clauditor install` for hooks-only)
- No behavior change — login still exits cleanly when preconditions aren't met

## Context
A user reported that running `clauditor login` in a non-git directory produced an unhelpful error with no guidance on what to do next. This fix keeps the strict semantics (login = hub auth, requires git) but gives users clear next steps.

## Test plan
- [ ] `npx tsc --noEmit` — clean build
- [ ] `npx vitest run` — all tests pass
- [ ] Manual: run `clauditor login` in a non-git dir → new error message shown
- [ ] Manual: run `clauditor login` in a git dir → unchanged behavior