### PR TITLE
feat: add `clauditor init` to wire AI tool into team knowledge

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -471,11 +471,118 @@ async function loginDeviceFlow(hubUrl: string, remoteUrl: string, developerHash:
     console.log(`\n  ✓ Logged in to team "${result.team_name}" (${result.plan})`)
     console.log(`  Connected: ${remoteUrl} → ${result.team_name}`)
     console.log(`\n  Knowledge will sync automatically during sessions on this project.`)
+    console.log(`  Next: run \`clauditor init\` to wire your AI tool into team knowledge.`)
   } catch (err) {
     console.error(`\n  ✗ ${err instanceof Error ? err.message : err}`)
     process.exit(1)
   }
 }
+
+// ─── clauditor init ──────────────────────────────────────────────
+
+program
+  .command('init')
+  .description('Add the "## Knowledge" instruction to your AI tool\'s rules file')
+  .option('--tool <tool>', 'claude_code | codex | cursor | claude_desktop | other')
+  .option('--hub-url <url>', 'Hub URL', DEFAULT_HUB_URL)
+  .option('-y, --yes', 'Skip the confirmation prompt')
+  .action(async (options: { tool?: string; hubUrl?: string; yes?: boolean }) => {
+    const { getGitRemoteUrl } = await import('./hub/git-project.js')
+    const { getProjectHubConfig } = await import('./config.js')
+    const {
+      detectTool,
+      pathForTool,
+      writeInstruction,
+      notifyHub,
+      INSTRUCTION_BLOCK,
+    } = await import('./hub/init-instruction.js')
+
+    const remoteUrl = getGitRemoteUrl()
+    const cwd = process.cwd()
+
+    // Resolve tool: --tool flag → detection → interactive prompt
+    const validTools = ['claude_code', 'codex', 'cursor', 'claude_desktop', 'other'] as const
+    type Tool = typeof validTools[number]
+
+    let tool: Tool | null = null
+    if (options.tool) {
+      if (!validTools.includes(options.tool as Tool)) {
+        console.error(`\n  ✗ Unknown tool "${options.tool}". Valid: ${validTools.join(', ')}`)
+        process.exit(1)
+      }
+      tool = options.tool as Tool
+    } else {
+      const detected = detectTool(cwd)
+      if (detected) {
+        tool = detected
+        console.log(`\n  Detected ${tool} from existing config file.`)
+      } else {
+        const readline = await import('node:readline')
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+        console.log('\n  Which AI tool are you using?')
+        validTools.forEach((t, i) => console.log(`    ${i + 1}. ${t}`))
+        const answer = await new Promise<string>((r) => rl.question('\n  Choice (1-5): ', (a) => { rl.close(); r(a.trim()) }))
+        const choice = parseInt(answer, 10)
+        if (!choice || choice < 1 || choice > validTools.length) {
+          console.error('\n  ✗ Invalid choice.')
+          process.exit(1)
+        }
+        tool = validTools[choice - 1]
+      }
+    }
+
+    const target = pathForTool(tool)
+
+    if (!target) {
+      console.log(`\n  ${tool === 'claude_desktop' ? 'Claude Desktop' : 'Your tool'} has no per-project config file.`)
+      console.log(`  Paste this into your custom instructions or starter prompt:\n`)
+      console.log('  ─────────────────────────────────────────────')
+      console.log(INSTRUCTION_BLOCK.split('\n').map((l) => '  ' + l).join('\n'))
+      console.log('  ─────────────────────────────────────────────')
+      console.log(`\n  When it's in place, click "I've added it" in the dashboard.`)
+      return
+    }
+
+    // Confirm before writing (skip with --yes)
+    if (!options.yes) {
+      const readline = await import('node:readline')
+      const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+      const answer = await new Promise<string>((r) =>
+        rl.question(`\n  Write the "## Knowledge" block to ${target}? (Y/n) `, (a) => { rl.close(); r(a.trim().toLowerCase()) })
+      )
+      if (answer === 'n' || answer === 'no') {
+        console.log('  Aborted.')
+        return
+      }
+    }
+
+    const result = writeInstruction(cwd, tool)
+    if (result.status === 'manual_required') {
+      // Shouldn't reach here — pathForTool already filtered, but be safe.
+      console.log(`\n  Manual step required for ${tool}.`)
+      return
+    }
+
+    if (result.status === 'already_present') {
+      console.log(`\n  ✓ ${result.path} already contains a clauditor knowledge block — left it untouched.`)
+    } else {
+      console.log(`\n  ✓ ${result.created ? 'Created' : 'Updated'} ${result.path}`)
+    }
+
+    // Notify hub (best-effort — older hubs lack this endpoint)
+    if (remoteUrl) {
+      const hubCfg = getProjectHubConfig(remoteUrl)
+      if (hubCfg?.apiKey) {
+        const hubUrl = options.hubUrl || hubCfg.url || DEFAULT_HUB_URL
+        const ok = await notifyHub(hubUrl, hubCfg.apiKey)
+        if (ok) {
+          console.log(`  ✓ Dashboard step marked complete.`)
+        }
+      } else {
+        console.log(`  (Run \`clauditor login\` to sync this to your team's dashboard.)`)
+      }
+    }
+  })
 
 // ─── clauditor sync ──────────────────────────────────────────────
 

--- a/src/hub/init-instruction.test.ts
+++ b/src/hub/init-instruction.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  detectTool,
+  pathForTool,
+  hasInstruction,
+  writeInstruction,
+  INSTRUCTION_BLOCK,
+} from './init-instruction.js'
+
+const TMP = '/tmp/test-clauditor-init'
+
+beforeEach(() => {
+  rmSync(TMP, { recursive: true, force: true })
+  mkdirSync(TMP, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(TMP, { recursive: true, force: true })
+})
+
+describe('detectTool', () => {
+  it('detects claude_code from CLAUDE.md', () => {
+    writeFileSync(resolve(TMP, 'CLAUDE.md'), 'hello')
+    expect(detectTool(TMP)).toBe('claude_code')
+  })
+  it('detects codex from AGENTS.md', () => {
+    writeFileSync(resolve(TMP, 'AGENTS.md'), 'hello')
+    expect(detectTool(TMP)).toBe('codex')
+  })
+  it('detects cursor from .cursor/rules', () => {
+    mkdirSync(resolve(TMP, '.cursor/rules'), { recursive: true })
+    expect(detectTool(TMP)).toBe('cursor')
+  })
+  it('detects cursor from .cursorrules', () => {
+    writeFileSync(resolve(TMP, '.cursorrules'), 'hello')
+    expect(detectTool(TMP)).toBe('cursor')
+  })
+  it('returns null when nothing matches', () => {
+    expect(detectTool(TMP)).toBe(null)
+  })
+})
+
+describe('pathForTool', () => {
+  it('returns null for claude_desktop + other', () => {
+    expect(pathForTool('claude_desktop')).toBe(null)
+    expect(pathForTool('other')).toBe(null)
+  })
+  it('returns the right relative path for supported tools', () => {
+    expect(pathForTool('claude_code')).toBe('CLAUDE.md')
+    expect(pathForTool('codex')).toBe('AGENTS.md')
+    expect(pathForTool('cursor')).toBe('.cursor/rules/clauditor.mdc')
+  })
+})
+
+describe('hasInstruction', () => {
+  it('detects clauditor_research mention', () => {
+    expect(hasInstruction('something clauditor_research something')).toBe(true)
+  })
+  it('returns false for unrelated content', () => {
+    expect(hasInstruction('# My project\nTyped with TypeScript')).toBe(false)
+  })
+})
+
+describe('writeInstruction', () => {
+  it('creates the file when missing', () => {
+    const r = writeInstruction(TMP, 'claude_code')
+    expect(r).toEqual({ status: 'written', path: 'CLAUDE.md', created: true })
+    expect(readFileSync(resolve(TMP, 'CLAUDE.md'), 'utf-8')).toBe(INSTRUCTION_BLOCK)
+  })
+
+  it('appends to an existing file non-destructively', () => {
+    writeFileSync(resolve(TMP, 'CLAUDE.md'), '# Existing\n\nContent here.\n')
+    const r = writeInstruction(TMP, 'claude_code')
+    expect(r.status).toBe('written')
+    const content = readFileSync(resolve(TMP, 'CLAUDE.md'), 'utf-8')
+    expect(content).toContain('# Existing')
+    expect(content).toContain('Content here.')
+    expect(content).toContain(INSTRUCTION_BLOCK.trim())
+  })
+
+  it('skips if already present', () => {
+    writeFileSync(resolve(TMP, 'CLAUDE.md'), '# Existing\n\nWe use clauditor_research a lot.\n')
+    const before = readFileSync(resolve(TMP, 'CLAUDE.md'), 'utf-8')
+    const r = writeInstruction(TMP, 'claude_code')
+    expect(r.status).toBe('already_present')
+    expect(readFileSync(resolve(TMP, 'CLAUDE.md'), 'utf-8')).toBe(before)
+  })
+
+  it('creates nested directories for cursor path', () => {
+    const r = writeInstruction(TMP, 'cursor')
+    expect(r.status).toBe('written')
+    expect(existsSync(resolve(TMP, '.cursor/rules/clauditor.mdc'))).toBe(true)
+  })
+
+  it('returns manual_required for claude_desktop', () => {
+    expect(writeInstruction(TMP, 'claude_desktop')).toEqual({ status: 'manual_required', tool: 'claude_desktop' })
+  })
+})

--- a/src/hub/init-instruction.ts
+++ b/src/hub/init-instruction.ts
@@ -1,0 +1,105 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+
+export type AiTool = 'claude_code' | 'codex' | 'cursor' | 'claude_desktop' | 'other'
+
+export const INSTRUCTION_HEADER = '## Knowledge'
+
+export const INSTRUCTION_BODY = `Before answering questions or writing code, check Clauditor's team knowledge via its MCP tools (clauditor_research, clauditor_get_brief, clauditor_get_gotchas, clauditor_who_knows). If you learn something new during this session, save it with clauditor_save_learning.`
+
+export const INSTRUCTION_BLOCK = `${INSTRUCTION_HEADER}\n${INSTRUCTION_BODY}\n`
+
+export interface ToolTarget {
+  tool: AiTool
+  /** Relative path the instruction lives in. null for claude_desktop. */
+  path: string | null
+  /** Human-readable description of where it went. */
+  description: string
+}
+
+const TOOL_PATHS: Record<Exclude<AiTool, 'claude_desktop' | 'other'>, string> = {
+  claude_code: 'CLAUDE.md',
+  codex: 'AGENTS.md',
+  cursor: '.cursor/rules/clauditor.mdc',
+}
+
+/**
+ * Detect which AI tool the repo is set up for by looking for config files.
+ * Returns the first match; null if none found.
+ */
+export function detectTool(cwd: string): AiTool | null {
+  if (existsSync(resolve(cwd, 'CLAUDE.md'))) return 'claude_code'
+  if (existsSync(resolve(cwd, 'AGENTS.md'))) return 'codex'
+  if (existsSync(resolve(cwd, '.cursor/rules')) || existsSync(resolve(cwd, '.cursorrules'))) return 'cursor'
+  return null
+}
+
+export function pathForTool(tool: AiTool): string | null {
+  if (tool === 'claude_desktop' || tool === 'other') return null
+  return TOOL_PATHS[tool]
+}
+
+/**
+ * Returns true if the file already contains a clauditor knowledge block
+ * we shouldn't duplicate. We match on the literal mention of
+ * `clauditor_research` or `Clauditor's team knowledge` — either signals
+ * the block (or a user-edited variant of it) is already present.
+ */
+export function hasInstruction(content: string): boolean {
+  return content.includes('clauditor_research') || content.includes("Clauditor's team knowledge")
+}
+
+export type WriteResult =
+  | { status: 'written'; path: string; created: boolean }
+  | { status: 'already_present'; path: string }
+  | { status: 'manual_required'; tool: AiTool }
+
+/**
+ * Append the `## Knowledge` block to the appropriate file for `tool`.
+ *
+ * Non-destructive: if the file exists, we APPEND. If a clauditor block is
+ * already present (detected via `hasInstruction`), we return
+ * `already_present` and touch nothing.
+ *
+ * For tools without a per-project config file (claude_desktop, other) we
+ * return `manual_required` so the caller can print paste instructions.
+ */
+export function writeInstruction(cwd: string, tool: AiTool): WriteResult {
+  const relPath = pathForTool(tool)
+  if (!relPath) return { status: 'manual_required', tool }
+
+  const filePath = resolve(cwd, relPath)
+  const exists = existsSync(filePath)
+
+  if (exists) {
+    const current = readFileSync(filePath, 'utf-8')
+    if (hasInstruction(current)) {
+      return { status: 'already_present', path: relPath }
+    }
+    const sep = current.endsWith('\n\n') ? '' : current.endsWith('\n') ? '\n' : '\n\n'
+    writeFileSync(filePath, current + sep + INSTRUCTION_BLOCK)
+    return { status: 'written', path: relPath, created: false }
+  }
+
+  mkdirSync(dirname(filePath), { recursive: true })
+  writeFileSync(filePath, INSTRUCTION_BLOCK)
+  return { status: 'written', path: relPath, created: true }
+}
+
+/**
+ * Notify the hub that the instruction has been written. Best-effort —
+ * older hub versions won't have this endpoint, which is fine; the user
+ * can still click "I've added it" in the dashboard.
+ */
+export async function notifyHub(hubUrl: string, apiKey: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${hubUrl}/api/v1/setup/instruction-confirm`, {
+      method: 'POST',
+      headers: { 'X-Clauditor-Key': apiKey },
+      signal: AbortSignal.timeout(5000),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- New `clauditor init` command: writes a `## Knowledge` block to the repo's AI-tool rules file (`CLAUDE.md` / `AGENTS.md` / `.cursor/rules/clauditor.mdc`) so the assistant proactively calls Clauditor MCP tools instead of waiting for the user to ask.
- Tool resolution: `--tool` flag → filesystem auto-detect → interactive picker. `claude_desktop` and `other` print paste instructions (no per-project file).
- Notifies the hub via `POST /api/v1/setup/instruction-confirm` (best-effort — older hubs just skip, file is still written).
- Post-login flow now prints `Next: run \`clauditor init\`…` as a nudge.

## Safety
- Non-destructive: confirms before writing (unless `-y`), appends to existing files, dedups by marker so re-running is a no-op.
- Graceful degradation when not logged in (prints notice) or hub endpoint missing (warning only).
- 14 new vitest cases, full suite passes (340 / 340).

## Test plan
- [ ] `clauditor init` in a scratch repo with no config file → prompts, creates `CLAUDE.md`
- [ ] Re-run → reports `already contains a clauditor knowledge block — left it untouched`
- [ ] `clauditor init --tool=cursor -y` in empty dir → creates `.cursor/rules/clauditor.mdc`
- [ ] `clauditor init --tool=claude_desktop` → prints paste block, writes nothing
- [ ] `clauditor init` without login → writes file, skips hub notify with helpful message
- [ ] Logged in → step auto-advances in dashboard