### PR TITLE
feat: `clauditor run` — auto-restart on session rotation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -154,6 +154,21 @@ program
     console.log('')
   })
 
+// ─── clauditor run ───────────────────────────────────────────────
+
+program
+  .command('run')
+  .description('Run claude with auto-restart on session rotation')
+  .option('--max-restarts <n>', 'Max consecutive restarts before giving up', '10')
+  .option('--task <prompt>', 'Initial task prompt for the first session')
+  .action(async (opts: { maxRestarts: string; task?: string }) => {
+    const { runWithAutoRotation } = await import('./commands/run.js')
+    await runWithAutoRotation({
+      maxRestarts: parseInt(opts.maxRestarts, 10) || 10,
+      task: opts.task,
+    })
+  })
+
 // ─── clauditor install ────────────────────────────────────────────
 
 program

--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'node:events'
+
+// Mock child_process.spawn
+const mockSpawn = vi.fn()
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+  execSync: () => Buffer.from('/usr/bin/claude'),
+}))
+
+// Mock activity log — must return a thenable
+vi.mock('../features/activity-log.js', () => ({
+  logActivity: () => Promise.resolve(),
+}))
+
+import { runLoop } from './run.js'
+
+function createChild(exitCode: number | null, signal: string | null) {
+  const child = new EventEmitter()
+  setTimeout(() => child.emit('exit', exitCode, signal), 0)
+  return child
+}
+
+describe('runLoop', () => {
+  beforeEach(() => {
+    mockSpawn.mockReset()
+    vi.restoreAllMocks()
+  })
+
+  it('exits cleanly when claude exits with code 0', async () => {
+    mockSpawn.mockReturnValue(createChild(0, null))
+    const result = await runLoop({ maxRestarts: 3 })
+
+    expect(result).toEqual({ exitCode: 0, restarts: 0, reason: 'normal_exit' })
+    expect(mockSpawn).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops on SIGINT (user Ctrl+C)', async () => {
+    mockSpawn.mockReturnValue(createChild(null, 'SIGINT'))
+    const result = await runLoop({ maxRestarts: 3 })
+
+    expect(result).toEqual({ exitCode: 0, restarts: 0, reason: 'signal' })
+  })
+
+  it('stops on SIGTERM', async () => {
+    mockSpawn.mockReturnValue(createChild(null, 'SIGTERM'))
+    const result = await runLoop({ maxRestarts: 3 })
+
+    expect(result).toEqual({ exitCode: 0, restarts: 0, reason: 'signal' })
+  })
+
+  it('restarts on exit code 2 (rotation block)', async () => {
+    let now = 0
+    vi.spyOn(Date, 'now').mockImplementation(() => {
+      now += 10000
+      return now
+    })
+
+    let callCount = 0
+    mockSpawn.mockImplementation(() => {
+      callCount++
+      return createChild(callCount === 1 ? 2 : 0, null)
+    })
+
+    const result = await runLoop({ maxRestarts: 3 })
+
+    expect(result).toEqual({ exitCode: 0, restarts: 1, reason: 'normal_exit' })
+    expect(mockSpawn).toHaveBeenCalledTimes(2)
+  })
+
+  it('passes --task as -p flag only on first spawn', async () => {
+    let now = 0
+    vi.spyOn(Date, 'now').mockImplementation(() => {
+      now += 10000
+      return now
+    })
+
+    let callCount = 0
+    mockSpawn.mockImplementation(() => {
+      callCount++
+      return createChild(callCount === 1 ? 2 : 0, null)
+    })
+
+    await runLoop({ maxRestarts: 3, task: 'fix the bug' })
+
+    expect(mockSpawn.mock.calls[0][1]).toEqual(['-p', 'fix the bug'])
+    expect(mockSpawn.mock.calls[1][1]).toEqual([])
+  })
+
+  it('stops after max restarts reached', async () => {
+    let now = 0
+    vi.spyOn(Date, 'now').mockImplementation(() => {
+      now += 10000
+      return now
+    })
+
+    mockSpawn.mockImplementation(() => createChild(2, null))
+
+    const result = await runLoop({ maxRestarts: 2 })
+
+    expect(result.reason).toBe('max_restarts')
+    expect(result.restarts).toBe(3) // counter increments past limit before loop exits
+    expect(mockSpawn).toHaveBeenCalledTimes(3) // 1 initial + 2 restarts
+  })
+
+  it('detects crash loop (exit <5s) and stops', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1000)
+
+    mockSpawn.mockImplementation(() => createChild(2, null))
+
+    const result = await runLoop({ maxRestarts: 3 })
+
+    expect(result).toEqual({ exitCode: 1, restarts: 0, reason: 'crash_loop' })
+    expect(mockSpawn).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles spawn error gracefully', async () => {
+    const child = new EventEmitter()
+    mockSpawn.mockReturnValue(child)
+    setTimeout(() => child.emit('error', new Error('ENOENT')), 0)
+
+    const result = await runLoop({ maxRestarts: 3 })
+
+    expect(result).toEqual({ exitCode: 1, restarts: 0, reason: 'spawn_error' })
+  })
+
+  it('forwards non-2 exit code from claude', async () => {
+    mockSpawn.mockReturnValue(createChild(130, null))
+
+    const result = await runLoop({ maxRestarts: 3 })
+
+    expect(result).toEqual({ exitCode: 130, restarts: 0, reason: 'normal_exit' })
+  })
+})

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,0 +1,140 @@
+import { spawn } from 'node:child_process'
+import { execSync } from 'node:child_process'
+import { readFileSync, existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import { logActivity } from '../features/activity-log.js'
+
+const ROTATION_EXIT_CODE = 2
+const MIN_SESSION_MS = 5000 // if claude exits in <5s, likely a crash — don't restart
+
+export interface RunOptions {
+  maxRestarts: number
+  task?: string
+}
+
+export interface RunResult {
+  exitCode: number
+  restarts: number
+  reason: 'normal_exit' | 'signal' | 'max_restarts' | 'crash_loop' | 'spawn_error'
+}
+
+/**
+ * Run `claude` with auto-restart on session rotation.
+ *
+ * When clauditor's UserPromptSubmit hook blocks a session (exit code 2),
+ * this restarts `claude` automatically. The SessionStart hook injects
+ * the saved context into the fresh session — zero manual steps.
+ */
+export async function runWithAutoRotation(opts: RunOptions): Promise<void> {
+  preflight()
+  const result = await runLoop(opts)
+
+  if (result.reason === 'max_restarts') {
+    console.log(`\n  clauditor: max restarts (${opts.maxRestarts}) reached. Exiting.\n`)
+  }
+
+  process.exit(result.exitCode)
+}
+
+/**
+ * Core loop — returns instead of calling process.exit, making it testable.
+ */
+export async function runLoop(opts: RunOptions): Promise<RunResult> {
+  let restarts = 0
+
+  while (restarts <= opts.maxRestarts) {
+    const args: string[] = []
+    if (opts.task && restarts === 0) {
+      args.push('-p', opts.task)
+    }
+
+    if (restarts > 0) {
+      console.log(`\n  clauditor: session rotated — restarting (${restarts}/${opts.maxRestarts})...\n`)
+    }
+
+    const startTime = Date.now()
+
+    const { code, signal } = await spawnClaude(args)
+
+    const elapsed = Date.now() - startTime
+
+    // Spawn error
+    if (code === -1) {
+      return { exitCode: 1, restarts, reason: 'spawn_error' }
+    }
+
+    // User quit (Ctrl+C / Ctrl+D) or normal exit — stop
+    if (signal === 'SIGINT' || signal === 'SIGTERM') {
+      return { exitCode: 0, restarts, reason: 'signal' }
+    }
+
+    if (code !== ROTATION_EXIT_CODE) {
+      return { exitCode: code ?? 0, restarts, reason: 'normal_exit' }
+    }
+
+    // Exit code 2 = rotation block — restart
+    // But if the session lasted <5s, it's probably a crash loop
+    if (elapsed < MIN_SESSION_MS) {
+      console.error('\n  ✗ claude exited too quickly after restart — possible crash loop. Stopping.')
+      return { exitCode: 1, restarts, reason: 'crash_loop' }
+    }
+
+    restarts++
+    logActivity({
+      type: 'auto_rotation',
+      session: `restart-${restarts}`,
+      message: `Auto-restarted session (${restarts}/${opts.maxRestarts})`,
+    }).catch(() => {})
+  }
+
+  return { exitCode: 0, restarts, reason: 'max_restarts' }
+}
+
+/**
+ * Preflight checks — run once before the loop.
+ */
+function preflight(): void {
+  // Check claude is installed
+  try {
+    execSync('which claude', { stdio: 'ignore' })
+  } catch {
+    console.error('\n  ✗ `claude` CLI not found in PATH.')
+    console.error('    Install it first: https://docs.anthropic.com/en/docs/claude-code')
+    process.exit(1)
+  }
+
+  // Warn if hooks aren't installed
+  const settingsPath = resolve(homedir(), '.claude', 'settings.json')
+  if (existsSync(settingsPath)) {
+    try {
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+      const hasClauditorHooks = JSON.stringify(settings.hooks || {}).includes('clauditor hook')
+      if (!hasClauditorHooks) {
+        console.log('\n  ⚠ clauditor hooks not detected in ~/.claude/settings.json')
+        console.log('    Auto-rotation requires hooks. Run `clauditor install` first.\n')
+      }
+    } catch {}
+  } else {
+    console.log('\n  ⚠ ~/.claude/settings.json not found — hooks may not be installed.')
+    console.log('    Run `clauditor install` to set up hooks.\n')
+  }
+}
+
+function spawnClaude(args: string[]): Promise<{ code: number | null; signal: string | null }> {
+  return new Promise((resolve) => {
+    const child = spawn('claude', args, {
+      stdio: 'inherit',
+      detached: false,
+    })
+
+    child.on('error', (err) => {
+      console.error(`\n  ✗ Failed to spawn claude: ${err.message}`)
+      resolve({ code: -1, signal: null })
+    })
+
+    child.on('exit', (code, signal) => {
+      resolve({ code, signal })
+    })
+  })
+}

--- a/src/features/activity-log.ts
+++ b/src/features/activity-log.ts
@@ -9,7 +9,7 @@ const MAX_LOG_BYTES = 1_000_000 // rotate at ~1MB
 
 export interface ActivityEvent {
   timestamp: string
-  type: 'cache_warning' | 'loop_blocked' | 'resume_warning' | 'context_warning' | 'bash_compressed' | 'notification' | 'burn_rate_warning'
+  type: 'cache_warning' | 'loop_blocked' | 'resume_warning' | 'context_warning' | 'bash_compressed' | 'notification' | 'burn_rate_warning' | 'auto_rotation'
   session: string
   message: string
 }
@@ -89,6 +89,7 @@ const TYPE_ICONS: Record<ActivityEvent['type'], string> = {
   bash_compressed: '📦',
   notification: '🔔',
   burn_rate_warning: '📈',
+  auto_rotation: '🔄',
 }
 
 /**


### PR DESCRIPTION
Closes #127.

## Summary
- Adds `clauditor run` command that wraps the coding agent in a restart loop
- When the `UserPromptSubmit` hook blocks a session (exit code 2 = waste threshold), `clauditor run` auto-spawns a fresh session
- The `SessionStart` hook injects saved context into the new session — zero manual steps
- Supports `--task <prompt>` for agentic/background workflows

## How it works
```
clauditor run [--max-restarts 10] [--task "implement feature X"]
     │
     ├─ spawn agent CLI (stdio: inherit — full terminal passthrough)
     ├─ wait for exit
     │
     ├─ exit code 2 (hook block)?
     │     ├─ log rotation to activity log
     │     ├─ check max-restarts cap
     │     ├─ crash-loop guard (exit in <5s → stop)
     │     └─ restart → SessionStart hook auto-injects context
     │
     ├─ SIGINT (Ctrl+C)? → stop cleanly
     └─ exit 0 or 1? → stop
```

## Safety features
- **Crash-loop detection:** if the session exits in <5s, stops immediately
- **Max restarts cap:** default 10, configurable via `--max-restarts`
- **Signal forwarding:** Ctrl+C/SIGTERM stop cleanly, no restart
- **Preflight checks:** warns if hooks aren't installed

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 349/349 tests pass (9 new in `src/commands/run.test.ts`)
- [x] `npm run build` — `clauditor run --help` renders correctly
- [x] Smoke test: spawned agent session, SIGINT propagated cleanly
- [x] Manual test: `node dist/cli.js run` launches interactive session successfully

## Tests cover
- Normal exit (code 0) → stops
- SIGINT / SIGTERM → stops
- Exit code 2 (rotation) → restarts with context
- `--task` flag passed as `-p` on first spawn only
- Max restarts cap → stops after N
- Crash loop (<5s exit) → stops immediately
- Spawn error → stops gracefully
- Non-2 exit codes forwarded